### PR TITLE
fix: instantiate new PineconeAsyncioClient for each request

### DIFF
--- a/libs/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/pinecone/langchain_pinecone/embeddings.py
@@ -74,11 +74,9 @@ class PineconeEmbeddings(BaseModel, Embeddings):
     @property
     def async_client(self) -> PineconeAsyncioClient:
         """Lazily initialize the async client."""
-        if self._async_client is None:
-            self._async_client = PineconeAsyncioClient(
-                api_key=self.pinecone_api_key.get_secret_value(), source_tag="langchain"
-            )
-        return self._async_client
+        return PineconeAsyncioClient(
+            api_key=self.pinecone_api_key.get_secret_value(), source_tag="langchain"
+        )
 
     @model_validator(mode="before")
     @classmethod

--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -241,19 +241,17 @@ class PineconeVectorStore(VectorStore):
             client = PineconeClient(
                 api_key=self._pinecone_api_key, source_tag="langchain"
             )
-            self._index = client.Index(host=self._index_host)
+            return client.Index(host=self._index_host)
         return self._index
 
     @property
     def async_index(self) -> _IndexAsyncio:
         """Get asynchronous index instance."""
         if self._async_index is None:
-            if not hasattr(self, "_index_host"):
-                raise ValueError("No index host available")
             client = PineconeAsyncioClient(
                 api_key=self._pinecone_api_key, source_tag="langchain"
             )
-            self._async_index = client.IndexAsyncio(host=self.index.config.host)
+            return client.IndexAsyncio(host=self.index.config.host)
         return self._async_index
 
     @property


### PR DESCRIPTION
The [pinecone.control.pinecone_asyncio.PineconeAsyncioClient](https://sdk.pinecone.io/python/pinecone/control/pinecone_asyncio.html) class cleans up it's `aiohttp` sessions every single time it exits via asynchronous context manager.

Modify our instantiation of `PineconeAsyncioClient` to correctly handle this.

Fixes https://github.com/langchain-ai/langchain-pinecone/issues/16