### PR TITLE
chore: Rerank unit and integration tests

### DIFF
--- a/libs/pinecone/langchain_pinecone/__init__.py
+++ b/libs/pinecone/langchain_pinecone/__init__.py
@@ -1,5 +1,5 @@
 from langchain_pinecone.embeddings import PineconeEmbeddings, PineconeSparseEmbeddings
-from langchain_pinecone.pinecone_rerank import PineconeRerank
+from langchain_pinecone.rerank import PineconeRerank
 from langchain_pinecone.vectorstores import Pinecone, PineconeVectorStore
 from langchain_pinecone.vectorstores_sparse import PineconeSparseVectorStore
 

--- a/libs/pinecone/langchain_pinecone/__init__.py
+++ b/libs/pinecone/langchain_pinecone/__init__.py
@@ -9,5 +9,5 @@ __all__ = [
     "PineconeVectorStore",
     "PineconeSparseVectorStore",
     "Pinecone",
-    "PineconeRerank"
+    "PineconeRerank",
 ]

--- a/libs/pinecone/langchain_pinecone/rerank.py
+++ b/libs/pinecone/langchain_pinecone/rerank.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.callbacks.base import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
 from langchain_core.utils import secret_from_env
-from pinecone import Pinecone
+from pinecone import Pinecone  # type: ignore
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
 
 
 class PineconeRerank(BaseDocumentCompressor):
@@ -239,7 +242,7 @@ class PineconeRerank(BaseDocumentCompressor):
             return result_dicts
 
         except Exception as e:
-            print(f"Rerank error: {e}")
+            logger.error(f"Rerank error: {e}")
             return []
 
     def compress_documents(

--- a/libs/pinecone/tests/integration_tests/test_rerank.py
+++ b/libs/pinecone/tests/integration_tests/test_rerank.py
@@ -1,0 +1,108 @@
+import os
+
+import pytest
+from langchain_core.documents import Document
+
+from langchain_pinecone import PineconeRerank
+
+# Ensure environment variables are set for integration tests
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("PINECONE_API_KEY"), reason="Pinecone API key not set"
+)
+
+
+def test_pinecone_rerank_basic():
+    """Test basic reranking functionality."""
+    reranker = PineconeRerank(model="bge-reranker-v2-m3")
+    query = "What is the capital of France?"
+    documents = [
+        Document(page_content="Paris is the capital of France."),
+        Document(page_content="Berlin is the capital of Germany."),
+        Document(page_content="The Eiffel Tower is in Paris."),
+    ]
+
+    compressed_docs = reranker.compress_documents(documents=documents, query=query)
+
+    assert len(compressed_docs) > 0
+    assert isinstance(compressed_docs[0], Document)
+    # Basic check for score presence, actual score value depends on model
+    assert "relevance_score" in compressed_docs[0].metadata
+    # Check if the most relevant document is ranked higher (basic assumption)
+    assert "Paris is the capital of France." in compressed_docs[0].page_content
+
+
+def test_pinecone_rerank_top_n():
+    """Test reranking with a specific top_n value."""
+    reranker = PineconeRerank(model="bge-reranker-v2-m3", top_n=1)
+    query = "What is the capital of France?"
+    documents = [
+        Document(page_content="Paris is the capital of France."),
+        Document(page_content="Berlin is the capital of Germany."),
+        Document(page_content="The Eiffel Tower is in Paris."),
+    ]
+
+    compressed_docs = reranker.compress_documents(documents=documents, query=query)
+
+    assert len(compressed_docs) == 1
+    assert "Paris is the capital of France." in compressed_docs[0].page_content
+
+
+def test_pinecone_rerank_rank_fields():
+    """Test reranking using specific rank_fields."""
+    # Test ranking by the 'text' field explicitly (was 'content')
+    reranker = PineconeRerank(model="bge-reranker-v2-m3", rank_fields=["text"])
+    query = "Latest news on climate change."
+    documents = [
+        Document(
+            page_content="Article about renewable energy.", metadata={"id": "doc1"}
+        ),
+        Document(page_content="Report on economic growth.", metadata={"id": "doc2"}),
+        Document(
+            page_content="News on climate policy changes.", metadata={"id": "doc3"}
+        ),
+    ]
+
+    compressed_docs = reranker.compress_documents(documents=documents, query=query)
+
+    # Ensure we got results back
+    assert len(compressed_docs) > 0
+    assert isinstance(compressed_docs[0], Document)
+    assert "relevance_score" in compressed_docs[0].metadata
+
+    # Verify that the most relevant document contains climate-related content
+    # (the exact ordering might vary with model updates, so check more broadly)
+    climate_related = False
+    for doc in compressed_docs:
+        if "climate policy" in doc.page_content:
+            climate_related = True
+            break
+    assert climate_related, "Expected to find climate-related content in top results"
+
+
+def test_pinecone_rerank_with_parameters():
+    """Test reranking with additional model parameters."""
+    # Note: The specific parameters depend on the model. 'truncate' is common.
+    reranker = PineconeRerank(model="bge-reranker-v2-m3")
+    query = "Explain the concept of quantum entanglement."
+    documents = [
+        Document(page_content="Quantum entanglement is a physical phenomenon..."),
+        Document(page_content="Classical mechanics describes motion..."),
+    ]
+
+    # Get reranking results
+    compressed_docs = reranker.compress_documents(documents=documents, query=query)
+
+    assert len(compressed_docs) > 0
+    assert isinstance(compressed_docs[0], Document)
+    assert "relevance_score" in compressed_docs[0].metadata
+
+    # Check that quantum entanglement document is found
+    quantum_found = False
+    for doc in compressed_docs:
+        if "Quantum entanglement" in doc.page_content:
+            quantum_found = True
+            break
+    assert quantum_found, "Expected to find quantum entanglement document in results"
+
+
+# Add more tests for edge cases or specific model behaviors if necessary

--- a/libs/pinecone/tests/integration_tests/test_rerank.py
+++ b/libs/pinecone/tests/integration_tests/test_rerank.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_pinecone_rerank_basic():
+def test_pinecone_rerank_basic() -> None:
     """Test basic reranking functionality."""
     reranker = PineconeRerank(model="bge-reranker-v2-m3")
     query = "What is the capital of France?"
@@ -31,7 +31,7 @@ def test_pinecone_rerank_basic():
     assert "Paris is the capital of France." in compressed_docs[0].page_content
 
 
-def test_pinecone_rerank_top_n():
+def test_pinecone_rerank_top_n() -> None:
     """Test reranking with a specific top_n value."""
     reranker = PineconeRerank(model="bge-reranker-v2-m3", top_n=1)
     query = "What is the capital of France?"
@@ -47,7 +47,7 @@ def test_pinecone_rerank_top_n():
     assert "Paris is the capital of France." in compressed_docs[0].page_content
 
 
-def test_pinecone_rerank_rank_fields():
+def test_pinecone_rerank_rank_fields() -> None:
     """Test reranking using specific rank_fields."""
     # Test ranking by the 'text' field explicitly (was 'content')
     reranker = PineconeRerank(model="bge-reranker-v2-m3", rank_fields=["text"])
@@ -79,7 +79,7 @@ def test_pinecone_rerank_rank_fields():
     assert climate_related, "Expected to find climate-related content in top results"
 
 
-def test_pinecone_rerank_with_parameters():
+def test_pinecone_rerank_with_parameters() -> None:
     """Test reranking with additional model parameters."""
     # Note: The specific parameters depend on the model. 'truncate' is common.
     reranker = PineconeRerank(model="bge-reranker-v2-m3")
@@ -103,6 +103,3 @@ def test_pinecone_rerank_with_parameters():
             quantum_found = True
             break
     assert quantum_found, "Expected to find quantum entanglement document in results"
-
-
-# Add more tests for edge cases or specific model behaviors if necessary

--- a/libs/pinecone/tests/unit_tests/test_imports.py
+++ b/libs/pinecone/tests/unit_tests/test_imports.py
@@ -6,6 +6,7 @@ EXPECTED_ALL = [
     "PineconeVectorStore",
     "PineconeSparseVectorStore",
     "Pinecone",
+    "PineconeRerank",
 ]
 
 

--- a/libs/pinecone/tests/unit_tests/test_rerank.py
+++ b/libs/pinecone/tests/unit_tests/test_rerank.py
@@ -22,15 +22,19 @@ class TestPineconeRerank:
         """Fixture to provide a mocked rerank API response."""
         mock_result1 = MagicMock()
         mock_result1.id = "doc0"
+        mock_result1.index = 0
         mock_result1.score = 0.9
-        mock_result1.document = {"id": "doc0", "content": "Document 1 content"}
+        mock_result1.document = {"id": "doc0", "text": "Document 1 content"}
 
         mock_result2 = MagicMock()
         mock_result2.id = "doc1"
+        mock_result2.index = 1
         mock_result2.score = 0.7
-        mock_result2.document = {"id": "doc1", "content": "Document 2 content"}
+        mock_result2.document = {"id": "doc1", "text": "Document 2 content"}
 
-        return [mock_result1, mock_result2]
+        mock_response = MagicMock()
+        mock_response.data = [mock_result1, mock_result2]
+        return mock_response
 
     def test_initialization_with_api_key(self, mock_pinecone_client):
         """Test initialization with API key environment variable."""
@@ -107,10 +111,10 @@ class TestPineconeRerank:
     @pytest.mark.parametrize(
         "document_input, expected_output",
         [
-            ("just a string", {"id": "doc0", "content": "just a string"}),
+            ("just a string", {"id": "doc0", "text": "just a string"}),
             (
                 Document(page_content="doc content", metadata={"source": "test"}),
-                {"id": "doc0", "content": "doc content"},
+                {"id": "doc0", "text": "doc content"},
             ),
             (
                 {"id": "custom-id", "content": "dict content"},
@@ -159,9 +163,9 @@ class TestPineconeRerank:
             model="test-model",
             query=query,
             documents=[
-                {"id": "doc0", "content": "doc1 content"},
-                {"id": "doc1", "content": "doc2 content"},
-                {"id": "doc2", "content": "doc3 content"},
+                {"id": "doc0", "text": "doc1 content"},
+                {"id": "doc1", "text": "doc2 content"},
+                {"id": "doc2", "text": "doc3 content"},
             ],
             rank_fields=["text"],
             top_n=2,
@@ -173,12 +177,12 @@ class TestPineconeRerank:
         assert results[0]["id"] == "doc0"
         assert results[0]["score"] == 0.9
         assert results[0]["index"] == 0
-        assert results[0]["document"] == {"id": "doc0", "content": "Document 1 content"}
+        assert results[0]["document"] == {"id": "doc0", "text": "Document 1 content"}
 
         assert results[1]["id"] == "doc1"
         assert results[1]["score"] == 0.7
         assert results[1]["index"] == 1
-        assert results[1]["document"] == {"id": "doc1", "content": "Document 2 content"}
+        assert results[1]["document"] == {"id": "doc1", "text": "Document 2 content"}
 
     def test_compress_documents(self, mock_pinecone_client, mock_rerank_response):
         """Test compress_documents calls rerank and formats output as Documents."""
@@ -203,13 +207,13 @@ class TestPineconeRerank:
                     "id": "doc0",
                     "index": 0,
                     "score": 0.9,
-                    "document": {"id": "doc0", "content": "Document 1 content"},
+                    "document": {"id": "doc0", "text": "Document 1 content"},
                 },
                 {
                     "id": "doc1",
                     "index": 1,
                     "score": 0.7,
-                    "document": {"id": "doc1", "content": "Document 2 content"},
+                    "document": {"id": "doc1", "text": "Document 2 content"},
                 },
             ]
 
@@ -292,7 +296,7 @@ class TestPineconeRerank:
                     "id": "unknown-doc",
                     "index": None,
                     "score": 0.5,
-                    "document": {"id": "unknown-doc", "content": "Unknown content"},
+                    "document": {"id": "unknown-doc", "text": "Unknown content"},
                 }
             ]
 

--- a/libs/pinecone/tests/unit_tests/test_rerank.py
+++ b/libs/pinecone/tests/unit_tests/test_rerank.py
@@ -1,0 +1,306 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+from pinecone import Pinecone
+from pydantic import SecretStr
+
+from langchain_pinecone.rerank import PineconeRerank
+
+
+class TestPineconeRerank:
+    @pytest.fixture
+    def mock_pinecone_client(self):
+        """Fixture to provide a mocked Pinecone client."""
+        mock_client = MagicMock(spec=Pinecone)
+        mock_client.inference = MagicMock()
+        return mock_client
+
+    @pytest.fixture
+    def mock_rerank_response(self):
+        """Fixture to provide a mocked rerank API response."""
+        mock_result1 = MagicMock()
+        mock_result1.id = "doc0"
+        mock_result1.score = 0.9
+        mock_result1.document = {"id": "doc0", "content": "Document 1 content"}
+
+        mock_result2 = MagicMock()
+        mock_result2.id = "doc1"
+        mock_result2.score = 0.7
+        mock_result2.document = {"id": "doc1", "content": "Document 2 content"}
+
+        return [mock_result1, mock_result2]
+
+    def test_initialization_with_api_key(self, mock_pinecone_client):
+        """Test initialization with API key environment variable."""
+        with patch.dict(os.environ, {"PINECONE_API_KEY": "fake-api-key"}):
+            with patch(
+                "langchain_pinecone.rerank.Pinecone",
+                return_value=mock_pinecone_client,
+            ) as mock_pinecone_constructor:
+                reranker = PineconeRerank(model="test-model")
+                mock_pinecone_constructor.assert_called_once_with(
+                    api_key="fake-api-key"
+                )
+                assert reranker.client == mock_pinecone_client
+                assert reranker.model == "test-model"
+                assert reranker.top_n == 3  # Default value
+
+    def test_initialization_with_client(self, mock_pinecone_client):
+        """Test initialization with a provided Pinecone client instance."""
+        reranker = PineconeRerank(client=mock_pinecone_client, model="test-model")
+        assert reranker.client == mock_pinecone_client
+        assert reranker.model == "test-model"
+
+    def test_initialization_missing_model(self):
+        """Test initialization fails if model is not specified."""
+        with pytest.raises(ValueError, match="Did not find `model`!"):
+            PineconeRerank(pinecone_api_key=SecretStr("fake-key"))
+
+    def test_initialization_invalid_client_type(self):
+        """Test initialization fails with invalid client type."""
+        with pytest.raises(
+            ValueError, match="The 'client' parameter must be an instance of"
+        ):
+            PineconeRerank(client="not a pinecone client", model="test-model")
+
+    def test_validate_environment_with_api_key(self, mock_pinecone_client):
+        """Test validate_environment creates client with API key."""
+        with patch.dict(os.environ, {"PINECONE_API_KEY": "fake-api-key"}):
+            # Patch the Pinecone constructor directly rather than as a context manager
+            # This way it stays patched during the entire test
+            with patch(
+                "langchain_pinecone.rerank.Pinecone", return_value=mock_pinecone_client
+            ) as mock_pinecone_constructor:
+                # Create reranker with client set to None to force client creation
+                # We need to create a brand new client for testing validate_environment
+                reranker = PineconeRerank(model="test-model")
+                # Explicitly set client to None to ensure we test client creation
+                reranker.client = None
+
+                # Call validate_environment
+                result = reranker.validate_environment()
+
+                # Verify constructor was called with expected args
+                mock_pinecone_constructor.assert_called_with(api_key="fake-api-key")
+                assert result.client == mock_pinecone_client
+
+    def test_validate_environment_with_client(self, mock_pinecone_client):
+        """Test validate_environment keeps provided client."""
+        reranker = PineconeRerank(client=mock_pinecone_client, model="test-model")
+        result = reranker.validate_environment()
+        assert result.client == mock_pinecone_client
+
+    def test_validate_model_specified(self):
+        """Test validate_model_specified passes when model is set."""
+        reranker = PineconeRerank(
+            model="test-model", pinecone_api_key=SecretStr("fake-key")
+        )
+        reranker.validate_model_specified()  # Should not raise error
+
+    def test_validate_model_specified_missing(self):
+        """Test validate_model_specified fails when model is missing."""
+        with pytest.raises(ValueError, match="Did not find `model`!"):
+            PineconeRerank(pinecone_api_key=SecretStr("fake-key"))
+
+    @pytest.mark.parametrize(
+        "document_input, expected_output",
+        [
+            ("just a string", {"id": "doc0", "content": "just a string"}),
+            (
+                Document(page_content="doc content", metadata={"source": "test"}),
+                {"id": "doc0", "content": "doc content"},
+            ),
+            (
+                {"id": "custom-id", "content": "dict content"},
+                {"id": "custom-id", "content": "dict content"},
+            ),
+            (
+                {"content": "dict content without id"},
+                {"id": "doc0", "content": "dict content without id"},
+            ),
+        ],
+    )
+    def test__document_to_dict(self, document_input, expected_output):
+        """Test _document_to_dict handles different input types."""
+        reranker = PineconeRerank(
+            model="test-model", pinecone_api_key=SecretStr("fake-key")
+        )
+        result = reranker._document_to_dict(document_input, 0)
+        assert result == expected_output
+
+    def test_rerank_empty_documents(self, mock_pinecone_client):
+        """Test rerank returns empty list for empty documents."""
+        reranker = PineconeRerank(client=mock_pinecone_client, model="test-model")
+        results = reranker.rerank([], "query")
+        assert results == []
+        mock_pinecone_client.inference.rerank.assert_not_called()
+
+    def test_rerank_calls_api_and_formats_results(
+        self, mock_pinecone_client, mock_rerank_response
+    ):
+        """Test rerank calls API with correct args and formats results."""
+        mock_pinecone_client.inference.rerank.return_value = mock_rerank_response
+
+        reranker = PineconeRerank(
+            client=mock_pinecone_client,
+            model="test-model",
+            top_n=2,
+            rank_fields=["text"],
+            return_documents=True,
+        )
+        documents = ["doc1 content", "doc2 content", "doc3 content"]
+        query = "test query"
+
+        results = reranker.rerank(documents, query)
+
+        mock_pinecone_client.inference.rerank.assert_called_once_with(
+            model="test-model",
+            query=query,
+            documents=[
+                {"id": "doc0", "content": "doc1 content"},
+                {"id": "doc1", "content": "doc2 content"},
+                {"id": "doc2", "content": "doc3 content"},
+            ],
+            rank_fields=["text"],
+            top_n=2,
+            return_documents=True,
+            parameters={"truncate": "END"},
+        )
+
+        assert len(results) == 2
+        assert results[0]["id"] == "doc0"
+        assert results[0]["score"] == 0.9
+        assert results[0]["index"] == 0
+        assert results[0]["document"] == {"id": "doc0", "content": "Document 1 content"}
+
+        assert results[1]["id"] == "doc1"
+        assert results[1]["score"] == 0.7
+        assert results[1]["index"] == 1
+        assert results[1]["document"] == {"id": "doc1", "content": "Document 2 content"}
+
+    def test_compress_documents(self, mock_pinecone_client, mock_rerank_response):
+        """Test compress_documents calls rerank and formats output as Documents."""
+        # Setup reranker
+        reranker = PineconeRerank(
+            client=mock_pinecone_client, model="test-model", return_documents=True
+        )
+
+        # Prepare documents and query
+        documents = [
+            Document(page_content="Document 1 content", metadata={"source": "a"}),
+            Document(page_content="Document 2 content", metadata={"source": "b"}),
+            Document(page_content="Document 3 content", metadata={"source": "c"}),
+        ]
+        query = "test query"
+
+        # Patch the class's rerank method
+        with patch("langchain_pinecone.rerank.PineconeRerank.rerank") as mock_rerank:
+            # Configure mock to return formatted results
+            mock_rerank.return_value = [
+                {
+                    "id": "doc0",
+                    "index": 0,
+                    "score": 0.9,
+                    "document": {"id": "doc0", "content": "Document 1 content"},
+                },
+                {
+                    "id": "doc1",
+                    "index": 1,
+                    "score": 0.7,
+                    "document": {"id": "doc1", "content": "Document 2 content"},
+                },
+            ]
+
+            # Call the method under test
+            compressed_docs = reranker.compress_documents(documents, query)
+
+            # Verify rerank was called
+            mock_rerank.assert_called_once_with(documents, query)
+
+            # Verify results
+            assert len(compressed_docs) == 2
+            assert isinstance(compressed_docs[0], Document)
+            assert compressed_docs[0].page_content == "Document 1 content"
+            assert compressed_docs[0].metadata["source"] == "a"
+            assert compressed_docs[0].metadata["relevance_score"] == 0.9
+
+            assert isinstance(compressed_docs[1], Document)
+            assert compressed_docs[1].page_content == "Document 2 content"
+            assert compressed_docs[1].metadata["source"] == "b"
+            assert compressed_docs[1].metadata["relevance_score"] == 0.7
+
+    def test_compress_documents_no_return_documents(self, mock_pinecone_client):
+        """Test compress_documents when return_documents is False."""
+        # Setup reranker
+        reranker = PineconeRerank(
+            client=mock_pinecone_client, model="test-model", return_documents=False
+        )
+
+        # Prepare documents and query
+        documents = [
+            Document(page_content="Document 1 content", metadata={"source": "a"}),
+            Document(page_content="Document 2 content", metadata={"source": "b"}),
+        ]
+        query = "test query"
+
+        # Patch the class's rerank method
+        with patch("langchain_pinecone.rerank.PineconeRerank.rerank") as mock_rerank:
+            # Configure mock to return results without documents
+            mock_rerank.return_value = [
+                {"id": "doc0", "index": 0, "score": 0.9},
+                {"id": "doc1", "index": 1, "score": 0.7},
+            ]
+
+            # Call the method under test
+            compressed_docs = reranker.compress_documents(documents, query)
+
+            # Verify rerank was called
+            mock_rerank.assert_called_once_with(documents, query)
+
+            # Verify results
+            assert len(compressed_docs) == 2
+            assert isinstance(compressed_docs[0], Document)
+            assert compressed_docs[0].page_content == "Document 1 content"
+            assert compressed_docs[0].metadata["source"] == "a"
+            assert compressed_docs[0].metadata["relevance_score"] == 0.9
+
+            assert isinstance(compressed_docs[1], Document)
+            assert compressed_docs[1].page_content == "Document 2 content"
+            assert compressed_docs[1].metadata["source"] == "b"
+            assert compressed_docs[1].metadata["relevance_score"] == 0.7
+
+    def test_compress_documents_index_none(self, mock_pinecone_client):
+        """Test compress_documents handles results where index is None."""
+        # Setup reranker
+        reranker = PineconeRerank(
+            client=mock_pinecone_client, model="test-model", return_documents=True
+        )
+
+        # Prepare documents and query
+        documents = [
+            Document(page_content="Document 1 content", metadata={"source": "a"}),
+        ]
+        query = "test query"
+
+        # Patch the class's rerank method
+        with patch("langchain_pinecone.rerank.PineconeRerank.rerank") as mock_rerank:
+            # Configure mock to return a result with index=None
+            mock_rerank.return_value = [
+                {
+                    "id": "unknown-doc",
+                    "index": None,
+                    "score": 0.5,
+                    "document": {"id": "unknown-doc", "content": "Unknown content"},
+                }
+            ]
+
+            # Call the method under test
+            compressed_docs = reranker.compress_documents(documents, query)
+
+            # Verify rerank was called
+            mock_rerank.assert_called_once_with(documents, query)
+
+            # Verify no documents were returned since index is None
+            assert len(compressed_docs) == 0


### PR DESCRIPTION
This pull request refactors the `PineconeRerank` implementation by relocating it to a new module, enhancing its functionality, and adding comprehensive integration tests. The changes also include updates to ensure compatibility with the new structure and improved documentation.

### Refactoring and Relocation:
* The `PineconeRerank` class has been moved from `libs/pinecone/langchain_pinecone/pinecone_rerank.py` to `libs/pinecone/langchain_pinecone/rerank.py`. This includes re-importing it in `__init__.py` to reflect the new module structure. [[1]](diffhunk://#diff-1bfb47108ddeb9a0763e9a8b47761d931f37501bf022f3189736399733dd5b67L2-R2) [[2]](diffhunk://#diff-1bfb47108ddeb9a0763e9a8b47761d931f37501bf022f3189736399733dd5b67L12-R12)

### Enhancements to `PineconeRerank`:
* Updated the `_document_to_dict` method to use the `text` field instead of `content` for document representation, aligning with Pinecone's API defaults.
* Improved error handling and logging for reranking operations, including better validation of API responses and handling of potential exceptions.
* Enhanced the `rerank` method to provide detailed examples and documentation for usage, including support for custom rank fields and model parameters.

### Removal of Old Implementation:
* Deleted the original `PineconeRerank` implementation from `libs/pinecone/langchain_pinecone/pinecone_rerank.py` to avoid redundancy.

### Integration and Unit Testing:
* Added new integration tests in `libs/pinecone/tests/integration_tests/test_rerank.py` to validate the functionality of `PineconeRerank`, including tests for basic reranking, `top_n` filtering, custom rank fields, and additional parameters.
* Updated unit tests in `libs/pinecone/tests/unit_tests/test_imports.py` to include the relocated `PineconeRerank` in the import checks.