### PR TITLE
fix: unclosed client session error

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -251,7 +251,9 @@ class PineconeVectorStore(VectorStore):
             client = PineconeAsyncioClient(
                 api_key=self._pinecone_api_key, source_tag="langchain"
             )
-            return client.IndexAsyncio(host=self.index.config.host)
+            index =  client.IndexAsyncio(host=self.index.config.host)
+            asyncio.create_task(client.close())
+            return index
         return self._async_index
 
     @property


### PR DESCRIPTION
This is **temporary** fix for #36 to finally get async vector store working, but related code should be revised in general