### PR TITLE
Fix: Implement sync and async similarity_search_by_vector in PineconeVectorStore

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -386,6 +386,47 @@ class PineconeVectorStore(VectorStore):
                 await asyncio.gather(*tasks)
 
         return ids
+    
+    def similarity_search_by_vector(
+        self,
+        embedding: List[float],
+        *,
+        k: int = 4,
+        filter: Optional[dict] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Document]:
+        """Return documents most similar to the given embedding vector.
+
+        Wraps `similarity_search_by_vector_with_score` but strips the scores.
+        """
+        docs_and_scores = self.similarity_search_by_vector_with_score(
+            embedding=embedding,
+            k=k,
+            filter=filter,
+            namespace=namespace
+        )
+        return [doc for doc, _ in docs_and_scores]
+
+    async def asimilarity_search_by_vector(
+        self,
+        embedding: List[float],
+        *,
+        k: int = 4,
+        filter: Optional[dict] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Document]:
+        """Return documents most similar to the given embedding vector asynchronously.
+
+        Wraps `asimilarity_search_by_vector_with_score` but strips the scores.
+        """
+        docs_and_scores = await self.asimilarity_search_by_vector_with_score(
+            embedding=embedding,
+            k=k,
+            filter=filter,
+            namespace=namespace
+        )
+        return [doc for doc, _ in docs_and_scores]
+
 
     def similarity_search_with_score(
         self,


### PR DESCRIPTION
### Description

This PR implements both `similarity_search_by_vector()` and `asimilarity_search_by_vector()` methods for `PineconeVectorStore`.

Although these methods are referenced in documentation and defined in the base `VectorStore` class, they were not implemented in the PineconeVectorStore. This PR wraps the already existing `*_with_score` methods and returns only the documents, excluding scores.

### Changes

- Adds `similarity_search_by_vector()`: sync method without scores
- Adds `asimilarity_search_by_vector()`: async version
- Wraps `*_with_score` versions to avoid code duplication
- Ensures consistency with LangChain's documented VectorStore interface

### Why it matters

This fix ensures consistency between the official API docs and runtime behavior. It avoids confusion for users who are working with precomputed embeddings and expect a working `*_by_vector` method.

### Notes

- Fully backward-compatible
- Mirrors design of `similarity_search()` vs `similarity_search_with_score()`
