### PR TITLE
support llama-text-embed-v2 embeddings

### DIFF
--- a/libs/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/pinecone/langchain_pinecone/embeddings.py
@@ -124,6 +124,12 @@ class PineconeEmbeddings(BaseModel, Embeddings):
                 "document_params": {"input_type": "passage", "truncate": "END"},
                 "dimension": 1024,
             },
+            "llama-text-embed-v2": {
+                "batch_size": 96,
+                "query_params": {"input_type": "query", "truncate": "END"},
+                "document_params": {"input_type": "passage", "truncate": "END"},
+                "dimension": 1024,
+            },
         }
         model = values.get("model")
         if model in default_config_map:


### PR DESCRIPTION
The API currently fails when entering any embedding model aside from the default. No other models are configured and the API arguments end up being dropped. The current error happens due to the missing `input_type` parameter, but there likely would be more.

To fix this for at least the `llama-text-embed-v2` model, I duplicated the params for the `multilingual-e5-large` model. The recommended vector dimension is confirmed to be the same (but I did take the liberty in assuming the same batch size which does not seem to be documented).

There are more low hanging fruits, but at the very least, I think it is good to start with at least one new model that would allow for significantly bigger chunk sizes.