### PR TITLE
fix: reintroduces `async_req` parameter for sync parallelism

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -275,6 +275,7 @@ class PineconeVectorStore(VectorStore):
         batch_size: int = 32,
         embedding_chunk_size: int = 1000,
         *,
+        async_req: bool = True,
         id_prefix: Optional[str] = None,
         **kwargs: Any,
     ) -> List[str]:
@@ -291,6 +292,7 @@ class PineconeVectorStore(VectorStore):
             namespace: Optional pinecone namespace to add the texts to.
             batch_size: Batch size to use when adding the texts to the vectorstore.
             embedding_chunk_size: Chunk size to use when embedding the texts.
+            async_req: Whether runs asynchronously.
             id_prefix: Optional string to use as an ID prefix when upserting vectors.
 
         Returns:
@@ -312,17 +314,32 @@ class PineconeVectorStore(VectorStore):
 
         # For loops to avoid memory issues and optimize when using HTTP based embeddings
         # The first loop runs the embeddings, it benefits when using OpenAI embeddings
+        # The second loops runs the pinecone upsert asynchronously.
         for i in range(0, len(texts), embedding_chunk_size):
             chunk_texts = texts[i : i + embedding_chunk_size]
             chunk_ids = ids[i : i + embedding_chunk_size]
             chunk_metadatas = metadatas[i : i + embedding_chunk_size]
             embeddings = self._embedding.embed_documents(chunk_texts)
             vector_tuples = list(zip(chunk_ids, embeddings, chunk_metadatas))
-            self.index.upsert(
-                vectors=vector_tuples,
-                namespace=namespace,
-                **kwargs,
-            )
+            if async_req:
+                # Runs the pinecone upsert asynchronously.
+                async_res = [
+                    self.index.upsert(
+                        vectors=batch_vector_tuples,
+                        namespace=namespace,
+                        async_req=async_req,
+                        **kwargs,
+                    )
+                    for batch_vector_tuples in batch_iterate(batch_size, vector_tuples)
+                ]
+                [res.get() for res in async_res]
+            else:
+                self.index.upsert(
+                    vectors=vector_tuples,
+                    namespace=namespace,
+                    async_req=async_req,
+                    **kwargs,
+                )
 
         return ids
 
@@ -793,6 +810,7 @@ class PineconeVectorStore(VectorStore):
         upsert_kwargs: Optional[dict] = None,
         pool_threads: int = 4,
         embeddings_chunk_size: int = 1000,
+        async_req: bool = True,
         *,
         id_prefix: Optional[str] = None,
         **kwargs: Any,
@@ -834,6 +852,7 @@ class PineconeVectorStore(VectorStore):
             namespace=namespace,
             batch_size=batch_size,
             embedding_chunk_size=embeddings_chunk_size,
+            async_req=async_req,
             id_prefix=id_prefix,
             **(upsert_kwargs or {}),
         )

--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -292,7 +292,7 @@ class PineconeVectorStore(VectorStore):
             namespace: Optional pinecone namespace to add the texts to.
             batch_size: Batch size to use when adding the texts to the vectorstore.
             embedding_chunk_size: Chunk size to use when embedding the texts.
-            async_req: Whether runs asynchronously.
+            async_req: Whether runs asynchronously. Defaults to True.
             id_prefix: Optional string to use as an ID prefix when upserting vectors.
 
         Returns:

--- a/libs/pinecone/tests/unit_tests/test_vectorstores.py
+++ b/libs/pinecone/tests/unit_tests/test_vectorstores.py
@@ -80,7 +80,7 @@ def test_id_prefix() -> None:
     vectorstore = PineconeVectorStore(index, embedding, text_key)
     texts = ["alpha", "beta", "gamma", "delta", "epsilon"]
     id_prefix = "testing_prefixes"
-    vectorstore.add_texts(texts, id_prefix=id_prefix)
+    vectorstore.add_texts(texts, id_prefix=id_prefix, async_req=False)
 
 
 def test_sparse_vectorstore__raises_on_dense_embedding(mocker: MockerFixture) -> None:

--- a/libs/pinecone/tests/unit_tests/test_vectorstores.py
+++ b/libs/pinecone/tests/unit_tests/test_vectorstores.py
@@ -262,7 +262,7 @@ class TestVectorstores:
         vectorstore_cls: Type[PineconeVectorStore],
         mock_embedding_obj: str,
         mock_index: MockType,
-    ):
+    ) -> None:
         mock_embedding = request.getfixturevalue(mock_embedding_obj)
 
         mock_upsert_return = mocker.Mock()
@@ -288,7 +288,7 @@ class TestVectorstores:
         vectorstore_cls: Type[PineconeVectorStore],
         mock_embedding_obj: str,
         mock_index: MockType,
-    ):
+    ) -> None:
         mock_embedding = request.getfixturevalue(mock_embedding_obj)
 
         mock_upsert_return = mocker.Mock()

--- a/libs/pinecone/tests/unit_tests/test_vectorstores.py
+++ b/libs/pinecone/tests/unit_tests/test_vectorstores.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Type
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock, call
 
 import pytest
 from pinecone import SparseValues  # type: ignore[import-untyped]
-from pytest_mock import AsyncMockType, MockerFixture
+from pytest_mock import AsyncMockType, MockerFixture, MockType
 
 from langchain_pinecone.embeddings import PineconeEmbeddings, PineconeSparseEmbeddings
 from langchain_pinecone.vectorstores import PineconeVectorStore
@@ -21,7 +21,8 @@ else:
 @pytest.fixture
 def mock_embedding(mocker: MockerFixture) -> AsyncMockType:
     """Fixture for mock embedding function."""
-    mock_embedding = mocker.AsyncMock()
+    mock_embedding = mocker.AsyncMock(spec=PineconeEmbeddings)
+    mock_embedding.embed_documents = mocker.Mock(return_value=[[0.1, 0.2, 0.3]])
     mock_embedding.aembed_documents = mocker.AsyncMock(return_value=[[0.1, 0.2, 0.3]])
     return mock_embedding
 
@@ -30,6 +31,9 @@ def mock_embedding(mocker: MockerFixture) -> AsyncMockType:
 def mock_sparse_embedding(mocker: MockerFixture) -> AsyncMockType:
     """Fixture for mock embedding function."""
     mock_embedding = mocker.AsyncMock(spec=PineconeSparseEmbeddings)
+    mock_embedding.embed_documents = mocker.Mock(
+        return_value=[SparseValues(indices=[0, 28, 218], values=[0.34, 0.239, 0.92])]
+    )
     mock_embedding.aembed_documents = mocker.AsyncMock(
         return_value=[SparseValues(indices=[0, 28, 218], values=[0.34, 0.239, 0.92])]
     )
@@ -45,6 +49,7 @@ def mock_async_index(mocker: MockerFixture) -> AsyncMockType:
     mock_async_index = mocker.AsyncMock(spec=_IndexAsyncio)
     mock_async_index.config = mocker.Mock()
     mock_async_index.config.host = "example.org"
+    mock_async_index.config.api_key = "test"
     mock_async_index.__aenter__ = mocker.AsyncMock(return_value=mock_async_index)
     mock_async_index.__aexit__ = mocker.AsyncMock(return_value=None)
     mock_async_index.upsert = mocker.AsyncMock(return_value=None)
@@ -55,15 +60,16 @@ def mock_async_index(mocker: MockerFixture) -> AsyncMockType:
 
 
 @pytest.fixture
-def mock_index(mocker: MockerFixture) -> AsyncMockType:
+def mock_index(mocker: MockerFixture) -> MockType:
     """Fixture for mock async index."""
     # Import the actual _IndexAsyncio class to use as spec
     from pinecone.data import _Index
 
-    mock_index = mocker.AsyncMock(spec=_Index)
+    mock_index = mocker.Mock(spec=_Index)
     mock_index.config = mocker.Mock()
     mock_index.config.host = "example.org"
-    mock_index.upsert = mocker.AsyncMock(return_value=None)
+    mock_index.config.api_key = "test"
+    mock_index.upsert = mocker.Mock(return_value=mocker.Mock())
     mock_index.describe_index_stats = mocker.Mock(
         return_value={"vector_type": "sparse"}
     )
@@ -247,3 +253,59 @@ class TestVectorstores:
         test_filter = {"metadata_field": "value"}
         await vectorstore.adelete(filter=test_filter)
         mock_async_index.delete.assert_called_with(filter=test_filter, namespace=None)
+
+    @pytest.mark.asyncio
+    async def test_sync_req_with_async_req__use_future_parallelism(
+        self,
+        request: FixtureRequest,
+        mocker: MockerFixture,
+        vectorstore_cls: Type[PineconeVectorStore],
+        mock_embedding_obj: str,
+        mock_index: MockType,
+    ):
+        mock_embedding = request.getfixturevalue(mock_embedding_obj)
+
+        mock_upsert_return = mocker.Mock()
+        mock_index.upsert = mocker.Mock(return_value=mock_upsert_return)
+
+        # Create vectorstore
+        vectorstore = vectorstore_cls(
+            index=mock_index, embedding=mock_embedding, text_key="text"
+        )
+
+        texts = ["test"] * 3
+        vectorstore.add_texts(texts, async_req=True)
+        mock_embedding.embed_documents.assert_called_once_with(texts)
+
+        mock_index.upsert.assert_called_once()
+        mock_upsert_return.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_req_with_async_req__use_future_parallelism_multi(
+        self,
+        request: FixtureRequest,
+        mocker: MockerFixture,
+        vectorstore_cls: Type[PineconeVectorStore],
+        mock_embedding_obj: str,
+        mock_index: MockType,
+    ):
+        mock_embedding = request.getfixturevalue(mock_embedding_obj)
+
+        mock_upsert_return = mocker.Mock()
+        mock_index.upsert = mocker.Mock(return_value=mock_upsert_return)
+
+        # Create vectorstore
+        vectorstore = vectorstore_cls(
+            index=mock_index, embedding=mock_embedding, text_key="text"
+        )
+
+        texts = ["test"] * 3000  # 3x embedding_chunk_size
+        vectorstore.add_texts(texts, async_req=True)
+
+        # When async_req == True, we expect `upsert` to be called 3 times...
+        mock_index.upsert.assert_has_calls(
+            [call(vectors=ANY, namespace=ANY, async_req=ANY)] * 3  # type: ignore
+        )
+        # each upsert call will yield a `multiprocessing.pool.ApplyResult` object
+        # assert we fetch the future result 3 times
+        mock_upsert_return.get.assert_has_calls([call()] * 3)


### PR DESCRIPTION
## Describing the change

Pinecone has not deprecated the use of `async_req` parameter, and users should still be able to rely on this parameter to parallelise their requests when handling sync operations.

This change reintroduces this feature. 

Closes #38 