### PR TITLE
feat: support llama-text-embed-v2 embeddings

### DIFF
--- a/libs/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/pinecone/langchain_pinecone/embeddings.py
@@ -124,6 +124,12 @@ class PineconeEmbeddings(BaseModel, Embeddings):
                 "document_params": {"input_type": "passage", "truncate": "END"},
                 "dimension": 1024,
             },
+            "llama-text-embed-v2": {
+                "batch_size": 96,
+                "query_params": {"input_type": "query", "truncate": "END"},
+                "document_params": {"input_type": "passage", "truncate": "END"},
+                "dimension": 1024,
+            },
         }
         model = values.get("model")
         if model in default_config_map:


### PR DESCRIPTION
This pull request adds support for a new embedding model configuration in the `set_default_config` method of the `libs/pinecone/langchain_pinecone/embeddings.py` file.

### Key change:
* Added a new configuration for the `llama-text-embed-v2` model, including parameters for `batch_size`, `query_params`, `document_params`, and `dimension`. This configuration is now part of the `default_config_map` dictionary.