### PR TITLE
fix: sync and async similarity_search_by_vector methods

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -413,47 +413,36 @@ class PineconeVectorStore(VectorStore):
                 await asyncio.gather(*tasks)
 
         return ids
-    
+
     def similarity_search_by_vector(
         self,
         embedding: List[float],
-        *,
         k: int = 4,
-        filter: Optional[dict] = None,
-        namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Return documents most similar to the given embedding vector.
 
         Wraps `similarity_search_by_vector_with_score` but strips the scores.
         """
         docs_and_scores = self.similarity_search_by_vector_with_score(
-            embedding=embedding,
-            k=k,
-            filter=filter,
-            namespace=namespace
+            embedding=embedding, k=k, **kwargs
         )
         return [doc for doc, _ in docs_and_scores]
 
     async def asimilarity_search_by_vector(
         self,
         embedding: List[float],
-        *,
         k: int = 4,
-        filter: Optional[dict] = None,
-        namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Return documents most similar to the given embedding vector asynchronously.
 
         Wraps `asimilarity_search_by_vector_with_score` but strips the scores.
         """
         docs_and_scores = await self.asimilarity_search_by_vector_with_score(
-            embedding=embedding,
-            k=k,
-            filter=filter,
-            namespace=namespace
+            embedding=embedding, k=k, **kwargs
         )
         return [doc for doc, _ in docs_and_scores]
-
 
     def similarity_search_with_score(
         self,
@@ -461,6 +450,7 @@ class PineconeVectorStore(VectorStore):
         k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to query, along with scores.
 
@@ -474,7 +464,11 @@ class PineconeVectorStore(VectorStore):
             List of Documents most similar to the query and score for each
         """
         return self.similarity_search_by_vector_with_score(
-            self._embedding.embed_query(query), k=k, filter=filter, namespace=namespace
+            self._embedding.embed_query(query),
+            k=k,
+            filter=filter,
+            namespace=namespace,
+            **kwargs,
         )
 
     async def asimilarity_search_with_score(
@@ -483,6 +477,7 @@ class PineconeVectorStore(VectorStore):
         k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> list[tuple[Document, float]]:
         """Asynchronously return pinecone documents most similar to query, along with scores.
 
@@ -500,6 +495,7 @@ class PineconeVectorStore(VectorStore):
             k=k,
             filter=filter,
             namespace=namespace,
+            **kwargs,
         )
 
     def similarity_search_by_vector_with_score(
@@ -507,13 +503,12 @@ class PineconeVectorStore(VectorStore):
         embedding: List[float],
         *,
         k: int = 4,
-        filter: Optional[dict] = None,
-        namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to embedding, along with scores."""
+        namespace = kwargs.get("namespace", self._namespace)
+        filter = kwargs.get("filter")
 
-        if namespace is None:
-            namespace = self._namespace
         docs = []
         results = self.index.query(
             vector=embedding,
@@ -545,12 +540,11 @@ class PineconeVectorStore(VectorStore):
         embedding: List[float],
         *,
         k: int = 4,
-        filter: Optional[dict] = None,
-        namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to embedding, along with scores asynchronously."""
-        if namespace is None:
-            namespace = self._namespace
+        namespace = kwargs.get("namespace", self._namespace)
+        filter = kwargs.get("filter")
 
         docs = []
         idx = await self.async_index

--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -413,6 +413,47 @@ class PineconeVectorStore(VectorStore):
                 await asyncio.gather(*tasks)
 
         return ids
+    
+    def similarity_search_by_vector(
+        self,
+        embedding: List[float],
+        *,
+        k: int = 4,
+        filter: Optional[dict] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Document]:
+        """Return documents most similar to the given embedding vector.
+
+        Wraps `similarity_search_by_vector_with_score` but strips the scores.
+        """
+        docs_and_scores = self.similarity_search_by_vector_with_score(
+            embedding=embedding,
+            k=k,
+            filter=filter,
+            namespace=namespace
+        )
+        return [doc for doc, _ in docs_and_scores]
+
+    async def asimilarity_search_by_vector(
+        self,
+        embedding: List[float],
+        *,
+        k: int = 4,
+        filter: Optional[dict] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Document]:
+        """Return documents most similar to the given embedding vector asynchronously.
+
+        Wraps `asimilarity_search_by_vector_with_score` but strips the scores.
+        """
+        docs_and_scores = await self.asimilarity_search_by_vector_with_score(
+            embedding=embedding,
+            k=k,
+            filter=filter,
+            namespace=namespace
+        )
+        return [doc for doc, _ in docs_and_scores]
+
 
     def similarity_search_with_score(
         self,

--- a/libs/pinecone/langchain_pinecone/vectorstores_sparse.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores_sparse.py
@@ -351,6 +351,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
         k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to query, along with scores.
 
@@ -364,7 +365,11 @@ class PineconeSparseVectorStore(PineconeVectorStore):
             List of Documents most similar to the query and score for each
         """
         return self.similarity_search_by_vector_with_score(
-            self.embeddings.embed_query(query), k=k, filter=filter, namespace=namespace
+            self.embeddings.embed_query(query),
+            k=k,
+            filter=filter,
+            namespace=namespace,
+            **kwargs,
         )
 
     async def asimilarity_search_with_score(
@@ -373,6 +378,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
         k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> list[tuple[Document, float]]:
         """Asynchronously return pinecone documents most similar to query, along with scores.
 
@@ -390,6 +396,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
             k=k,
             filter=filter,
             namespace=namespace,
+            **kwargs,
         )
 
     def similarity_search_by_vector_with_score(
@@ -399,6 +406,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
         k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to embedding, along with scores."""
 
@@ -411,6 +419,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
             include_metadata=True,
             namespace=namespace,
             filter=filter,
+            **kwargs,
         )
         for res in results["matches"]:
             metadata = res["metadata"]
@@ -434,6 +443,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
         k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to embedding, along with scores asynchronously."""
         if namespace is None:
@@ -449,6 +459,7 @@ class PineconeSparseVectorStore(PineconeVectorStore):
                 include_metadata=True,
                 namespace=namespace,
                 filter=filter,
+                **kwargs,
             )
 
         for res in results["matches"]:


### PR DESCRIPTION
This pull request adds two new methods to the `vectorstores.py` file to enhance similarity search functionality. These methods provide both synchronous and asynchronous ways to retrieve documents based on their similarity to a given embedding vector, while stripping out the associated scores.

### Enhancements to similarity search:

* Added `similarity_search_by_vector` method to perform a synchronous similarity search by embedding vector, returning only the documents without scores. (`[libs/pinecone/langchain_pinecone/vectorstores.pyR417-R457](diffhunk://#diff-7d82bf404beeafbc48f2cacade4a116fd52f5d74f704c1f7da10e9e2f6b4a7c9R417-R457)`)
* Added `asimilarity_search_by_vector` method to perform an asynchronous similarity search by embedding vector, also returning only the documents without scores. (`[libs/pinecone/langchain_pinecone/vectorstores.pyR417-R457](diffhunk://#diff-7d82bf404beeafbc48f2cacade4a116fd52f5d74f704c1f7da10e9e2f6b4a7c9R417-R457)`)