### PR TITLE
chore: release v0.2.11

### DIFF
--- a/libs/pinecone/pyproject.toml
+++ b/libs/pinecone/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "langchain-openai>=0.3.11",
 ]
 name = "langchain-pinecone"
-version = "0.2.10"
+version = "0.2.11"
 description = "An integration package connecting Pinecone and LangChain"
 readme = "README.md"
 

--- a/libs/pinecone/uv.lock
+++ b/libs/pinecone/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "langchain-pinecone"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
This pull request includes a version bump for the `langchain-pinecone` package to prepare for a new release.

* [`libs/pinecone/pyproject.toml`](diffhunk://#diff-557a04fb36ee1df9ce178b9f93b2f7120c5d892e82ce71532f45ebda5afd8f38L17-R17): Updated the package version from `0.2.10` to `0.2.11`.