### PR TITLE
Bug fix: Added simsid in dev group

### DIFF
--- a/libs/pinecone/pyproject.toml
+++ b/libs/pinecone/pyproject.toml
@@ -37,7 +37,12 @@ test = [
 codespell = ["codespell<3.0.0,>=2.2.0"]
 test_integration = ["langchain-openai<0.4,>=0.3.6"]
 lint = ["ruff<1.0,>=0.5"]
-dev = ["ipykernel>=6.29.5", "langchain-core", "pip>=25.0.1"]
+dev = [
+    "ipykernel>=6.29.5",
+    "langchain-core",
+    "pip>=25.0.1",
+    "simsimd>=5.9.11",
+]
 typing = ["mypy<2.0,>=1.10", "simsimd<6.0.0,>=5.0.0"]
 
 [tool.mypy]

--- a/libs/pinecone/uv.lock
+++ b/libs/pinecone/uv.lock
@@ -895,6 +895,7 @@ dev = [
     { name = "ipykernel" },
     { name = "langchain-core" },
     { name = "pip" },
+    { name = "simsimd" },
 ]
 lint = [
     { name = "ruff" },
@@ -932,6 +933,7 @@ dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "langchain-core" },
     { name = "pip", specifier = ">=25.0.1" },
+    { name = "simsimd", specifier = ">=5.9.11" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.5,<1.0" }]
 test = [


### PR DESCRIPTION
## Add `simsimd` to dev group to fix manual installation requirement

The `simsimd` library was missing from the `dev` dependency group, causing it to need manual installation for development workflows. This change adds it to the dev group so it's automatically installed with `uv sync`.

Fixes: https://github.com/langchain-ai/langchain-pinecone/issues/50