### PR TITLE
refactor: update code to use pydantic v2 imports

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -19,11 +19,11 @@ import numpy as np
 from langchain_core._api.deprecation import deprecated
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils.iter import batch_iterate
 from langchain_core.vectorstores import VectorStore
 from pinecone import Pinecone as PineconeClient
 from pinecone import PineconeAsyncio as PineconeAsyncioClient
+from pydantic import SecretStr
 
 # conditional imports based on pinecone version
 try:

--- a/libs/pinecone/pyproject.toml
+++ b/libs/pinecone/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langchain-openai>=0.3.11",
     "httpx>=0.28.0",
     "simsimd>=5.9.11",
+    "pydantic>=2.11.1",
 ]
 name = "langchain-pinecone"
 version = "0.2.12"

--- a/libs/pinecone/uv.lock
+++ b/libs/pinecone/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <3.14"
 resolution-markers = [
     "python_full_version == '3.11.*'",
@@ -884,6 +884,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "numpy" },
     { name = "pinecone", extra = ["asyncio"] },
+    { name = "pydantic" },
     { name = "simsimd" },
 ]
 
@@ -924,6 +925,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.3.11" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pinecone", extras = ["asyncio"], specifier = ">=6.0.0,<8.0.0" },
+    { name = "pydantic", specifier = ">=2.11.1" },
     { name = "simsimd", specifier = ">=5.9.11" },
 ]
 


### PR DESCRIPTION
Replaced deprecated `langchain_core.pydantic_v1` import with `pydantic` directly to address the following warning:
```
LangChainDeprecationWarning: As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. The langchain_core.pydantic_v1 module was a compatibility shim for pydantic v1, and should no longer be used. Please update the code to import from Pydantic directly.

For example, replace imports like: `from langchain_core.pydantic_v1 import BaseModel`
with: `from pydantic import BaseModel`
or the v1 compatibility namespace if you are working in a code base that has not been fully upgraded to pydantic 2 yet.         from pydantic.v1 import BaseModel

  from langchain_pinecone.vectorstores import Pinecone, PineconeVectorStore
```