### PR TITLE
bug: Fix namespace fallback in Pinecone similarity search

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -534,8 +534,11 @@ class PineconeVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to embedding, along with scores."""
-        namespace = kwargs.get("namespace", self._namespace)
+        namespace = kwargs.get("namespace")
         filter = kwargs.get("filter")
+
+        if namespace is None:
+            namespace = self._namespace
 
         docs = []
         results = self.index.query(
@@ -571,8 +574,11 @@ class PineconeVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return pinecone documents most similar to embedding, along with scores asynchronously."""
-        namespace = kwargs.get("namespace", self._namespace)
+        namespace = kwargs.get("namespace")
         filter = kwargs.get("filter")
+
+        if namespace is None:
+            namespace = self._namespace
 
         docs = []
         idx = await self.async_index

--- a/libs/pinecone/tests/unit_tests/test_vectorstores.py
+++ b/libs/pinecone/tests/unit_tests/test_vectorstores.py
@@ -533,3 +533,47 @@ class TestVectorstores:
 
         # ... we're persisting the connection and only closing on completion
         mock_async_client.return_value.IndexAsyncio.return_value.__aexit__.assert_called_once()
+
+
+def test_similarity_search_by_vector_with_score__defaults_to_store_namespace(
+    mock_embedding: AsyncMockType,
+    mock_index: MockType,
+) -> None:
+    """Ensure sync similarity search falls back to the configured namespace when None is passed."""
+    mock_index.query = Mock(return_value={"matches": []})
+    vectorstore = PineconeVectorStore(
+        index=mock_index,
+        embedding=mock_embedding,
+        text_key="text",
+        namespace="default-ns",
+    )
+
+    vectorstore.similarity_search_by_vector_with_score(
+        [0.1, 0.2, 0.3],
+        namespace=None,
+    )
+
+    assert mock_index.query.call_args.kwargs["namespace"] == "default-ns"
+
+
+@pytest.mark.asyncio
+async def test_asimilarity_search_by_vector_with_score__defaults_to_store_namespace(
+    mocker: MockerFixture,
+    mock_embedding: AsyncMockType,
+    mock_async_index: AsyncMockType,
+) -> None:
+    """Ensure async similarity search falls back to the configured namespace when None is passed."""
+    mock_async_index.query = mocker.AsyncMock(return_value={"matches": []})
+    vectorstore = PineconeVectorStore(
+        index=mock_async_index,
+        embedding=mock_embedding,
+        text_key="text",
+        namespace="default-ns",
+    )
+
+    await vectorstore.asimilarity_search_by_vector_with_score(
+        [0.1, 0.2, 0.3],
+        namespace=None,
+    )
+
+    assert mock_async_index.query.call_args.kwargs["namespace"] == "default-ns"


### PR DESCRIPTION
**Summary**
- Restore default namespace when callers pass `namespace=None` in similarity search.
- Apply consistent fallback across sync and async code paths.
- Add regression tests to prevent reoccurrence.

**Context**
- Regression introduced in v0.2.11: using `kwargs.get("namespace", self._namespace)` means an explicit `None` in kwargs is treated as a real value, skipping the intended fallback to the store’s configured namespace. This breaks retriever flows that propagate `namespace=None`.
- Fixes: https://github.com/langchain-ai/langchain-pinecone/issues/80

**Changes**
- Treat `None` as “use the store’s default namespace”:
  - `libs/pinecone/langchain_pinecone/vectorstores.py:537`
  - `libs/pinecone/langchain_pinecone/vectorstores.py:577`
- Add tests validating fallback in both sync and async paths:
  - `libs/pinecone/tests/unit_tests/test_vectorstores.py:538`
  - `libs/pinecone/tests/unit_tests/test_vectorstores.py:560`

**Before (problematic)**
```python
# namespace=None in kwargs prevents fallback to self._namespace
namespace = kwargs.get("namespace", self._namespace)
```

**After (fixed)**
```python
# Sync
namespace = kwargs.get("namespace")
if namespace is None:
    namespace = self._namespace

# Async
namespace = kwargs.get("namespace")
if namespace is None:
    namespace = self._namespace
```

**Tests**
- Sync: `test_similarity_search_by_vector_with_score__defaults_to_store_namespace`
  - Ensures Pinecone receives the store’s namespace when `namespace=None` is passed.
- Async: `test_asimilarity_search_by_vector_with_score__defaults_to_store_namespace`
  - Mirrors the above for the async path.

