### PR TITLE
docs: Migrate REST Docstrings to Markdown for New Reference Site

### DIFF
--- a/libs/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/pinecone/langchain_pinecone/embeddings.py
@@ -41,41 +41,41 @@ class PineconeEmbeddings(BaseModel, Embeddings):
     """PineconeEmbeddings embedding model.
 
     Example:
-        .. code-block:: python
+        ```python
+        from langchain_pinecone import PineconeEmbeddings
+        from langchain_pinecone import PineconeVectorStore
+        from langchain_core.documents import Document
 
-            from langchain_pinecone import PineconeEmbeddings
-            from langchain_pinecone import PineconeVectorStore
-            from langchain_core.documents import Document
+        # Initialize embeddings with a specific model
+        embeddings = PineconeEmbeddings(model="multilingual-e5-large")
 
-            # Initialize embeddings with a specific model
-            embeddings = PineconeEmbeddings(model="multilingual-e5-large")
+        # Embed a single query
+        query_embedding = embeddings.embed_query("What is machine learning?")
 
-            # Embed a single query
-            query_embedding = embeddings.embed_query("What is machine learning?")
+        # Embed multiple documents
+        docs = ["Document 1 content", "Document 2 content"]
+        doc_embeddings = embeddings.embed_documents(docs)
 
-            # Embed multiple documents
-            docs = ["Document 1 content", "Document 2 content"]
-            doc_embeddings = embeddings.embed_documents(docs)
+        # Use with PineconeVectorStore
+        from pinecone import Pinecone
 
-            # Use with PineconeVectorStore
-            from pinecone import Pinecone
+        pc = Pinecone(api_key="your-api-key")
+        index = pc.Index("your-index-name")
 
-            pc = Pinecone(api_key="your-api-key")
-            index = pc.Index("your-index-name")
+        vectorstore = PineconeVectorStore(
+            index=index,
+            embedding=embeddings
+        )
 
-            vectorstore = PineconeVectorStore(
-                index=index,
-                embedding=embeddings
-            )
+        # Add documents to vector store
+        vectorstore.add_documents([
+            Document(page_content="Hello, world!"),
+            Document(page_content="This is a test.")
+        ])
 
-            # Add documents to vector store
-            vectorstore.add_documents([
-                Document(page_content="Hello, world!"),
-                Document(page_content="This is a test.")
-            ])
-
-            # Search for similar documents
-            results = vectorstore.similarity_search("hello", k=2)
+        # Search for similar documents
+        results = vectorstore.similarity_search("hello", k=2)
+        ```
     """
 
     # Clients
@@ -267,71 +267,71 @@ class PineconeSparseEmbeddings(PineconeEmbeddings):
     """PineconeSparseEmbeddings embedding model.
 
     Example:
-        .. code-block:: python
+        ```python
+        from langchain_pinecone import PineconeSparseEmbeddings
+        from langchain_pinecone import PineconeVectorStore
+        from langchain_core.documents import Document
 
-            from langchain_pinecone import PineconeSparseEmbeddings
-            from langchain_pinecone import PineconeVectorStore
-            from langchain_core.documents import Document
+        # Initialize sparse embeddings
+        sparse_embeddings = PineconeSparseEmbeddings(model="pinecone-sparse-english-v0")
 
-            # Initialize sparse embeddings
-            sparse_embeddings = PineconeSparseEmbeddings(model="pinecone-sparse-english-v0")
+        # Embed a single query (returns SparseValues)
+        query_embedding = sparse_embeddings.embed_query("What is machine learning?")
+        # query_embedding contains SparseValues with indices and values
 
-            # Embed a single query (returns SparseValues)
-            query_embedding = sparse_embeddings.embed_query("What is machine learning?")
-            # query_embedding contains SparseValues with indices and values
+        # Embed multiple documents
+        docs = ["Document 1 content", "Document 2 content"]
+        doc_embeddings = sparse_embeddings.embed_documents(docs)
 
-            # Embed multiple documents
-            docs = ["Document 1 content", "Document 2 content"]
-            doc_embeddings = sparse_embeddings.embed_documents(docs)
+        # Use with an index configured for sparse vectors
+        from pinecone import Pinecone
 
-            # Use with an index configured for sparse vectors
-            from pinecone import Pinecone
+        pc = Pinecone(api_key="your-api-key")
 
-            pc = Pinecone(api_key="your-api-key")
-
-            # Create index with sparse embeddings support
-            if not pc.has_index("sparse-index"):
-                pc.create_index_for_model(
-                    name="sparse-index",
-                    cloud="aws",
-                    region="us-east-1",
-                    embed={
-                        "model": "pinecone-sparse-english-v0",
-                        "field_map": {"text": "chunk_text"},
-                        "metric": "dotproduct",
-                        "read_parameters": {},
-                        "write_parameters": {}
-                    }
-                )
-
-            index = pc.Index("sparse-index")
-
-            # IMPORTANT: Use PineconeSparseVectorStore for sparse vectors
-            # The regular PineconeVectorStore won't work with sparse embeddings
-            from langchain_pinecone.vectorstores_sparse import PineconeSparseVectorStore
-
-            # Initialize sparse vector store with sparse embeddings
-            vector_store = PineconeSparseVectorStore(
-                index=index,
-                embedding=sparse_embeddings
+        # Create index with sparse embeddings support
+        if not pc.has_index("sparse-index"):
+            pc.create_index_for_model(
+                name="sparse-index",
+                cloud="aws",
+                region="us-east-1",
+                embed={
+                    "model": "pinecone-sparse-english-v0",
+                    "field_map": {"text": "chunk_text"},
+                    "metric": "dotproduct",
+                    "read_parameters": {},
+                    "write_parameters": {}
+                }
             )
 
-            # Add documents
-            from uuid import uuid4
+        index = pc.Index("sparse-index")
 
-            documents = [
-                Document(page_content="Machine learning is awesome", metadata={"source": "article"}),
-                Document(page_content="Neural networks power modern AI", metadata={"source": "book"})
-            ]
+        # IMPORTANT: Use PineconeSparseVectorStore for sparse vectors
+        # The regular PineconeVectorStore won't work with sparse embeddings
+        from langchain_pinecone.vectorstores_sparse import PineconeSparseVectorStore
 
-            # Generate unique IDs for each document
-            uuids = [str(uuid4()) for _ in range(len(documents))]
+        # Initialize sparse vector store with sparse embeddings
+        vector_store = PineconeSparseVectorStore(
+            index=index,
+            embedding=sparse_embeddings
+        )
 
-            # Add documents to the vector store
-            vector_store.add_documents(documents=documents, ids=uuids)
+        # Add documents
+        from uuid import uuid4
 
-            # Search for similar documents
-            results = vector_store.similarity_search("machine learning", k=2)
+        documents = [
+            Document(page_content="Machine learning is awesome", metadata={"source": "article"}),
+            Document(page_content="Neural networks power modern AI", metadata={"source": "book"})
+        ]
+
+        # Generate unique IDs for each document
+        uuids = [str(uuid4()) for _ in range(len(documents))]
+
+        # Add documents to the vector store
+        vector_store.add_documents(documents=documents, ids=uuids)
+
+        # Search for similar documents
+        results = vector_store.similarity_search("machine learning", k=2)
+        ```
     """
 
     @model_validator(mode="before")

--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -48,12 +48,12 @@ class PineconeVectorStore(VectorStore):
     """Pinecone vector store integration.
 
     Setup:
-        Install ``langchain-pinecone`` and set the environment variable ``PINECONE_API_KEY``.
+        Install `langchain-pinecone` and set the environment variable `PINECONE_API_KEY`.
 
-        .. code-block:: bash
-
-            pip install -qU langchain-pinecone
-            export PINECONE_API_KEY = "your-pinecone-api-key"
+        ```bash
+        pip install -qU langchain-pinecone
+        export PINECONE_API_KEY="your-pinecone-api-key"
+        ```
 
     Key init args — indexing params:
         embedding: Embeddings
@@ -66,118 +66,118 @@ class PineconeVectorStore(VectorStore):
 
     # TODO: Replace with relevant init params.
     Instantiate:
-        .. code-block:: python
+        ```python
+        import time
+        import os
+        from pinecone import Pinecone, ServerlessSpec
+        from langchain_pinecone import PineconeVectorStore
+        from langchain_openai import OpenAIEmbeddings
 
-            import time
-            import os
-            from pinecone import Pinecone, ServerlessSpec
-            from langchain_pinecone import PineconeVectorStore
-            from langchain_openai import OpenAIEmbeddings
+        pc = Pinecone(api_key=os.environ.get("PINECONE_API_KEY"))
 
-            pc = Pinecone(api_key=os.environ.get("PINECONE_API_KEY"))
+        index_name = "langchain-test-index"  # change if desired
 
-            index_name = "langchain-test-index"  # change if desired
+        existing_indexes = [index_info["name"] for index_info in pc.list_indexes()]
 
-            existing_indexes = [index_info["name"] for index_info in pc.list_indexes()]
+        if index_name not in existing_indexes:
+            pc.create_index(
+                name=index_name,
+                dimension=1536,
+                metric="cosine",
+                spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+                deletion_protection="enabled",  # Defaults to "disabled"
+            )
+            while not pc.describe_index(index_name).status["ready"]:
+                time.sleep(1)
 
-            if index_name not in existing_indexes:
-                pc.create_index(
-                    name=index_name,
-                    dimension=1536,
-                    metric="cosine",
-                    spec=ServerlessSpec(cloud="aws", region="us-east-1"),
-                    deletion_protection="enabled",  # Defaults to "disabled"
-                )
-                while not pc.describe_index(index_name).status["ready"]:
-                    time.sleep(1)
-
-            index = pc.Index(index_name)
-            vector_store = PineconeVectorStore(index=index, embedding=OpenAIEmbeddings())
+        index = pc.Index(index_name)
+        vector_store = PineconeVectorStore(index=index, embedding=OpenAIEmbeddings())
+        ```
 
     Add Documents:
-        .. code-block:: python
+        ```python
+        from langchain_core.documents import Document
 
-            from langchain_core.documents import Document
+        document_1 = Document(page_content="foo", metadata={"baz": "bar"})
+        document_2 = Document(page_content="thud", metadata={"bar": "baz"})
+        document_3 = Document(page_content="i will be deleted :(")
 
-            document_1 = Document(page_content="foo", metadata={"baz": "bar"})
-            document_2 = Document(page_content="thud", metadata={"bar": "baz"})
-            document_3 = Document(page_content="i will be deleted :(")
-
-            documents = [document_1, document_2, document_3]
-            ids = ["1", "2", "3"]
-            vector_store.add_documents(documents=documents, ids=ids)
+        documents = [document_1, document_2, document_3]
+        ids = ["1", "2", "3"]
+        vector_store.add_documents(documents=documents, ids=ids)
+        ```
 
     Delete Documents:
-        .. code-block:: python
-
-            vector_store.delete(ids=["3"])
+        ```python
+        vector_store.delete(ids=["3"])
+        ```
 
     Search:
-        .. code-block:: python
+        ```python
+        results = vector_store.similarity_search(query="thud", k=1)
+        for doc in results:
+            print(f"* {doc.page_content} [{doc.metadata}]")
+        ```
 
-            results = vector_store.similarity_search(query="thud",k=1)
-            for doc in results:
-                print(f"* {doc.page_content} [{doc.metadata}]")
-
-        .. code-block:: python
-
-            * thud [{'bar': 'baz'}]
+        ```text
+        * thud [{'bar': 'baz'}]
+        ```
 
     Search with filter:
-        .. code-block:: python
+        ```python
+        results = vector_store.similarity_search(query="thud", k=1, filter={"bar": "baz"})
+        for doc in results:
+            print(f"* {doc.page_content} [{doc.metadata}]")
+        ```
 
-            results = vector_store.similarity_search(query="thud",k=1,filter={"bar": "baz"})
-            for doc in results:
-                print(f"* {doc.page_content} [{doc.metadata}]")
-
-        .. code-block:: python
-
-            * thud [{'bar': 'baz'}]
+        ```text
+        * thud [{'bar': 'baz'}]
+        ```
 
     Search with score:
-        .. code-block:: python
+        ```python
+        results = vector_store.similarity_search_with_score(query="qux", k=1)
+        for doc, score in results:
+            print(f"* [SIM={score:3f}] {doc.page_content} [{doc.metadata}]")
+        ```
 
-            results = vector_store.similarity_search_with_score(query="qux",k=1)
-            for doc, score in results:
-                print(f"* [SIM={score:3f}] {doc.page_content} [{doc.metadata}]")
-
-        .. code-block:: python
-
-            * [SIM=0.832268] foo [{'baz': 'bar'}]
+        ```text
+        * [SIM=0.832268] foo [{'baz': 'bar'}]
+        ```
 
     Async:
-        .. code-block:: python
+        ```python
+        # add documents
+        # await vector_store.aadd_documents(documents=documents, ids=ids)
 
-            # add documents
-            # await vector_store.aadd_documents(documents=documents, ids=ids)
+        # delete documents
+        # await vector_store.adelete(ids=["3"])
 
-            # delete documents
-            # await vector_store.adelete(ids=["3"])
+        # search
+        # results = vector_store.asimilarity_search(query="thud", k=1)
 
-            # search
-            # results = vector_store.asimilarity_search(query="thud",k=1)
+        # search with score
+        results = await vector_store.asimilarity_search_with_score(query="qux", k=1)
+        for doc, score in results:
+            print(f"* [SIM={score:3f}] {doc.page_content} [{doc.metadata}]")
+        ```
 
-            # search with score
-            results = await vector_store.asimilarity_search_with_score(query="qux",k=1)
-            for doc,score in results:
-                print(f"* [SIM={score:3f}] {doc.page_content} [{doc.metadata}]")
-
-        .. code-block:: python
-
-            * [SIM=0.832268] foo [{'baz': 'bar'}]
+        ```text
+        * [SIM=0.832268] foo [{'baz': 'bar'}]
+        ```
 
     Use as Retriever:
-        .. code-block:: python
+        ```python
+        retriever = vector_store.as_retriever(
+            search_type="mmr",
+            search_kwargs={"k": 1, "fetch_k": 2, "lambda_mult": 0.5},
+        )
+        retriever.invoke("thud")
+        ```
 
-            retriever = vector_store.as_retriever(
-                search_type="mmr",
-                search_kwargs={"k": 1, "fetch_k": 2, "lambda_mult": 0.5},
-            )
-            retriever.invoke("thud")
-
-        .. code-block:: python
-
-            [Document(metadata={'bar': 'baz'}, page_content='thud')]
+        ```text
+        [Document(metadata={'bar': 'baz'}, page_content='thud')]
+        ```
 
     """  # noqa: E501
 
@@ -906,19 +906,19 @@ class PineconeVectorStore(VectorStore):
         Setup: set the `PINECONE_API_KEY` environment variable to your Pinecone API key.
 
         Example:
-            .. code-block:: python
+            ```python
+            from langchain_pinecone import PineconeVectorStore, PineconeEmbeddings
 
-                from langchain_pinecone import PineconeVectorStore, PineconeEmbeddings
+            embeddings = PineconeEmbeddings(model="multilingual-e5-large")
 
-                embeddings = PineconeEmbeddings(model="multilingual-e5-large")
-
-                index_name = "my-index"
-                vectorstore = PineconeVectorStore.from_texts(
-                    texts,
-                    index_name=index_name,
-                    embedding=embedding,
-                    namespace=namespace,
-                )
+            index_name = "my-index"
+            vectorstore = PineconeVectorStore.from_texts(
+                texts,
+                index_name=index_name,
+                embedding=embedding,
+                namespace=namespace,
+            )
+            ```
         """
         pinecone_index = cls.get_pinecone_index(index_name, pool_threads)
         pinecone = cls(pinecone_index, embedding, text_key, namespace, **kwargs)


### PR DESCRIPTION

- Linked issue: https://github.com/langchain-ai/langchain-pinecone/issues/82
- Scope: Convert reStructuredText-style snippets in docstrings to Markdown/MkDocs syntax for the new reference site (Material for MkDocs), without changing runtime behavior.

## Summary
This PR updates inline docstrings to use Markdown fencing and conventions so they render correctly on the new documentation site at `reference.langchain.com`. It replaces legacy `.. code-block::` directives and normalizes inline code formatting. No functional code changes are included.

## Changes
- Replace `.. code-block:: {language}` with fenced code blocks.
- Normalize inline code to single backticks and format example outputs in fenced `text` blocks.
- Keep examples readable and consistent with MkDocs Material expectations.

## Files Updated
- `libs/pinecone/langchain_pinecone/vectorstores.py:48`
  - Primary class docstring for `PineconeVectorStore` migrated to Markdown, including setup, instantiate, add/search examples, and async usage.
- `libs/pinecone/langchain_pinecone/vectorstores.py:909`
  - Example block in `from_texts` docstring converted to Markdown fences.
- `libs/pinecone/langchain_pinecone/embeddings.py:44`
  - `PineconeEmbeddings` example usage converted to Markdown fences.
- `libs/pinecone/langchain_pinecone/embeddings.py:270`
  - `PineconeSparseEmbeddings` example usage converted to Markdown fences.

Notes:
- `libs/pinecone/langchain_pinecone/vectorstores_sparse.py` already uses Markdown-style examples; no reST directives found.
- `libs/pinecone/langchain_pinecone/rerank.py` does not contain reST admonitions or code-block directives requiring conversion.

## What’s Not Present (by design)
- Admonitions (`.. warning::`, `.. note::`, etc.), version markers (`.. versionchanged::`, `.. versionadded::`, `.. deprecated::`), dropdowns, or Sphinx cross-references were not found in the touched modules, so no conversions were required there.
- No changes to the build system or doc tooling are included in this PR.
