### PR TITLE
ci: skip integration tests when API keys are unavailable

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -50,6 +50,7 @@ jobs:
           make test
 
       - name: Run integration tests
+        if: ${{ env.PINECONE_API_KEY != '' }}
         shell: bash
         env:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds a condition to skip the integration test step in `_test.yml` when `PINECONE_API_KEY` is not set
- Fixes CI failures on Dependabot PRs (e.g. #102) which don't have access to repository secrets
- Unit tests and lint checks continue to run unconditionally

## Test plan
- [ ] Verify this PR's CI passes (integration tests should be skipped since this is not from a trusted context with secrets)
- [ ] After merge, rebase Dependabot PR #102 (`@dependabot rebase`) and confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)