### PR TITLE
chore(deps): bump requests 2.32.4 to 2.33.0 + fix CI for Dependabot

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -50,6 +50,7 @@ jobs:
           make test
 
       - name: Run integration tests
+        if: ${{ env.PINECONE_API_KEY != '' }}
         shell: bash
         env:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}

--- a/libs/pinecone/uv.lock
+++ b/libs/pinecone/uv.lock
@@ -1985,7 +1985,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1993,9 +1993,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `requests` from 2.32.4 to 2.33.0 in `/libs/pinecone` (includes CVE-2026-25645 fix)
- Fixes CI: skips integration tests when `PINECONE_API_KEY` is unavailable (Dependabot PRs don't have access to repo secrets)

Supersedes #102.

## Test plan
- [x] CI passes: unit tests, lint, compile integration tests all green
- [x] Integration test step is skipped (no API key in this context)