### PR TITLE
test(embeddings): add response-parsing and batching unit tests

### DIFF
--- a/libs/pinecone/tests/unit_tests/test_embeddings.py
+++ b/libs/pinecone/tests/unit_tests/test_embeddings.py
@@ -1,10 +1,13 @@
 from typing import Any, Type
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.utils import convert_to_secret_str
 from langchain_tests.unit_tests.embeddings import EmbeddingsTests
-from pinecone import PineconeAsyncio  # type: ignore[import-untyped]
+from pinecone import (
+    PineconeAsyncio,  # type: ignore[import-untyped]
+    SparseValues,  # type: ignore[import-untyped]
+)
 
 from langchain_pinecone import PineconeEmbeddings
 from langchain_pinecone.embeddings import PineconeSparseEmbeddings
@@ -193,3 +196,132 @@ class TestPineconeEmbeddingsConfig:
         result = await embeddings.alist_supported_models(vector_type="dense")
 
         assert result == mock_response
+
+
+class TestPineconeEmbeddingsResponseParsing:
+    """Tests that embed_* methods correctly unpack r["values"] from inference responses."""
+
+    @pytest.fixture
+    def emb(self) -> PineconeEmbeddings:
+        return PineconeEmbeddings(model=MODEL_NAME, pinecone_api_key=API_KEY)
+
+    def test_embed_documents_parses_values(
+        self, mocker: Any, emb: PineconeEmbeddings
+    ) -> None:
+        fake = [{"values": [0.1, 0.2, 0.3]}, {"values": [0.4, 0.5, 0.6]}]
+        mocker.patch.object(PineconeEmbeddings, "_embed_texts", return_value=fake)
+        result = emb.embed_documents(["text 1", "text 2"])
+        assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    def test_embed_query_parses_values(
+        self, mocker: Any, emb: PineconeEmbeddings
+    ) -> None:
+        fake = [{"values": [0.1, 0.2, 0.3]}]
+        mocker.patch.object(PineconeEmbeddings, "_embed_texts", return_value=fake)
+        result = emb.embed_query("query text")
+        assert result == [0.1, 0.2, 0.3]
+
+    async def test_aembed_documents_parses_values(
+        self, mocker: Any, emb: PineconeEmbeddings
+    ) -> None:
+        fake = [{"values": [0.1, 0.2, 0.3]}, {"values": [0.4, 0.5, 0.6]}]
+        mocker.patch.object(
+            PineconeEmbeddings, "_aembed_texts", new=AsyncMock(return_value=fake)
+        )
+        result = await emb.aembed_documents(["text 1", "text 2"])
+        assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    async def test_aembed_query_parses_values(
+        self, mocker: Any, emb: PineconeEmbeddings
+    ) -> None:
+        fake = [{"values": [0.1, 0.2, 0.3]}]
+        mocker.patch.object(
+            PineconeEmbeddings, "_aembed_texts", new=AsyncMock(return_value=fake)
+        )
+        result = await emb.aembed_query("query text")
+        assert result == [0.1, 0.2, 0.3]
+
+    def test_embed_documents_batches_in_order(
+        self, mocker: Any, emb: PineconeEmbeddings
+    ) -> None:
+        emb.batch_size = 2
+        batch_results = [
+            [{"values": [0.1, 0.2]}, {"values": [0.3, 0.4]}],
+            [{"values": [0.5, 0.6]}, {"values": [0.7, 0.8]}],
+            [{"values": [0.9, 1.0]}],
+        ]
+        mock_embed = mocker.Mock(side_effect=batch_results)
+        mocker.patch.object(PineconeEmbeddings, "_embed_texts", mock_embed)
+
+        result = emb.embed_documents(["a", "b", "c", "d", "e"])
+
+        assert mock_embed.call_count == 3
+        assert mock_embed.call_args_list[0].kwargs["texts"] == ["a", "b"]
+        assert mock_embed.call_args_list[1].kwargs["texts"] == ["c", "d"]
+        assert mock_embed.call_args_list[2].kwargs["texts"] == ["e"]
+        assert result == [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]
+
+
+class TestPineconeSparseEmbeddingsResponseParsing:
+    """Tests that sparse embed_* methods correctly build SparseValues from responses."""
+
+    @pytest.fixture
+    def sparse_emb(self) -> PineconeSparseEmbeddings:
+        return PineconeSparseEmbeddings(
+            model=SPARSE_MODEL_NAME, pinecone_api_key=API_KEY
+        )
+
+    def test_sparse_embed_documents_builds_sparsevalues(
+        self, mocker: Any, sparse_emb: PineconeSparseEmbeddings
+    ) -> None:
+        fake = [
+            {"sparse_indices": [1, 5, 10], "sparse_values": [0.1, 0.2, 0.3]},
+            {"sparse_indices": [2, 7], "sparse_values": [0.4, 0.5]},
+        ]
+        mocker.patch.object(PineconeSparseEmbeddings, "_embed_texts", return_value=fake)
+        result = sparse_emb.embed_documents(["text 1", "text 2"])
+        assert len(result) == 2
+        assert isinstance(result[0], SparseValues)
+        assert result[0].indices == [1, 5, 10]
+        assert result[0].values == [0.1, 0.2, 0.3]
+        assert isinstance(result[1], SparseValues)
+        assert result[1].indices == [2, 7]
+        assert result[1].values == [0.4, 0.5]
+
+    def test_sparse_embed_query_builds_sparsevalues(
+        self, mocker: Any, sparse_emb: PineconeSparseEmbeddings
+    ) -> None:
+        fake = [{"sparse_indices": [1, 5], "sparse_values": [0.1, 0.2]}]
+        mocker.patch.object(PineconeSparseEmbeddings, "_embed_texts", return_value=fake)
+        result = sparse_emb.embed_query("query text")
+        assert isinstance(result, SparseValues)
+        assert result.indices == [1, 5]
+        assert result.values == [0.1, 0.2]
+
+    async def test_sparse_aembed_documents_builds_sparsevalues(
+        self, mocker: Any, sparse_emb: PineconeSparseEmbeddings
+    ) -> None:
+        fake = [
+            {"sparse_indices": [1, 5, 10], "sparse_values": [0.1, 0.2, 0.3]},
+            {"sparse_indices": [2, 7], "sparse_values": [0.4, 0.5]},
+        ]
+        mocker.patch.object(
+            PineconeSparseEmbeddings, "_aembed_texts", new=AsyncMock(return_value=fake)
+        )
+        result = await sparse_emb.aembed_documents(["text 1", "text 2"])
+        assert len(result) == 2
+        assert isinstance(result[0], SparseValues)
+        assert result[0].indices == [1, 5, 10]
+        assert result[0].values == [0.1, 0.2, 0.3]
+
+    async def test_sparse_aembed_query_builds_sparsevalues(
+        self, mocker: Any, sparse_emb: PineconeSparseEmbeddings
+    ) -> None:
+        fake = [{"sparse_indices": [1, 5], "sparse_values": [0.1, 0.2]}]
+        mocker.patch.object(
+            PineconeSparseEmbeddings, "_aembed_texts", new=AsyncMock(return_value=fake)
+        )
+        result = await sparse_emb.aembed_query("query text")
+        assert isinstance(result, SparseValues)
+        assert result.indices == [1, 5]
+        assert result.values == [0.1, 0.2]


### PR DESCRIPTION
## Purpose

Adds direct unit coverage for how `PineconeEmbeddings` and `PineconeSparseEmbeddings` parse inference API responses into their return values. This is the seam most likely to break on a `pinecone` 8.x SDK bump (goal #1 of the maintenance mission). Previously `test_embeddings.py` only covered config defaults and model-name validation — nothing asserted that `r["values"]` / `r["sparse_indices"]` / `r["sparse_values"]` are correctly unpacked.

## Solution

Two new test classes added to `tests/unit_tests/test_embeddings.py`:

**`TestPineconeEmbeddingsResponseParsing`** (dense)
- `test_embed_documents_parses_values` — `embed_documents` unpacks `r["values"]` into `List[List[float]]`
- `test_embed_query_parses_values` — `embed_query` returns the first row as `List[float]` (not nested)
- `test_aembed_documents_parses_values` — async twin parses identically to sync
- `test_aembed_query_parses_values` — async twin parses identically to sync
- `test_embed_documents_batches_in_order` — with `batch_size=2` and 5 texts, `_embed_texts` is called 3× with correct slices and results concatenate in input order

**`TestPineconeSparseEmbeddingsResponseParsing`** (sparse)
- `test_sparse_embed_documents_builds_sparsevalues` — builds `SparseValues(indices=..., values=...)` from `r["sparse_indices"]` / `r["sparse_values"]`
- `test_sparse_embed_query_builds_sparsevalues` — same for single-query path
- `test_sparse_aembed_documents_builds_sparsevalues` — async twin
- `test_sparse_aembed_query_builds_sparsevalues` — async twin

All tests are socket-disabled, fully mocked, and rely on the existing `patch_pinecone_model_listing` + `mock_pinecone` autouse fixtures. Sanity-checked: tests fail red when `r["values"]` is renamed. No public API changes.

## Notes

Integration tests were not run locally (no `PINECONE_API_KEY`). Upstream CI will exercise the integration gate.