### PR TITLE
fix(rerank): propagate API errors instead of swallowing into []

### DIFF
--- a/libs/pinecone/langchain_pinecone/rerank.py
+++ b/libs/pinecone/langchain_pinecone/rerank.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -14,8 +13,6 @@ from langchain_pinecone._utilities import (
     aget_pinecone_supported_models,
     get_pinecone_supported_models,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class PineconeRerank(BaseDocumentCompressor):
@@ -164,42 +161,37 @@ class PineconeRerank(BaseDocumentCompressor):
             for i, doc in enumerate(documents)
         ]
 
-        try:
-            client = self._get_sync_client()
+        client = self._get_sync_client()
 
-            # Use self.model if model is None
-            model_to_use = model if model is not None else self.model
-            if model_to_use is None:  # This should never happen due to validator
-                raise ValueError("No model specified for reranking")
+        # Use self.model if model is None
+        model_to_use = model if model is not None else self.model
+        if model_to_use is None:  # This should never happen due to validator
+            raise ValueError("No model specified for reranking")
 
-            rerank_result = client.inference.rerank(
-                model=model_to_use,
-                query=query,
-                documents=docs,
-                rank_fields=rank_fields or self.rank_fields or ["text"],
-                top_n=top_n or self.top_n,
-                return_documents=self.return_documents,
-                parameters=self._rerank_params(model=model_to_use, truncate=truncate),
-            )
+        rerank_result = client.inference.rerank(
+            model=model_to_use,
+            query=query,
+            documents=docs,
+            rank_fields=rank_fields or self.rank_fields or ["text"],
+            top_n=top_n or self.top_n,
+            return_documents=self.return_documents,
+            parameters=self._rerank_params(model=model_to_use, truncate=truncate),
+        )
 
-            result_dicts = []
-            for result_item_data in rerank_result.data:
-                result_dict = {
-                    "id": result_item_data.document.id,
-                    "index": result_item_data.index,
-                    "score": result_item_data.score,
-                }
+        result_dicts = []
+        for result_item_data in rerank_result.data:
+            result_dict = {
+                "id": result_item_data.document.id,
+                "index": result_item_data.index,
+                "score": result_item_data.score,
+            }
 
-                if self.return_documents:
-                    result_dict["document"] = result_item_data.document.to_dict()
+            if self.return_documents:
+                result_dict["document"] = result_item_data.document.to_dict()
 
-                result_dicts.append(result_dict)
+            result_dicts.append(result_dict)
 
-            return result_dicts
-
-        except Exception as e:
-            logger.error(f"Rerank error: {e}")
-            return []
+        return result_dicts
 
     async def arerank(
         self,
@@ -220,41 +212,37 @@ class PineconeRerank(BaseDocumentCompressor):
             for i, doc in enumerate(documents)
         ]
 
-        try:
-            client = await self._get_async_client()
+        client = await self._get_async_client()
 
-            # Use self.model if model is None
-            model_to_use = model if model is not None else self.model
-            if model_to_use is None:  # This should never happen due to validator
-                raise ValueError("No model specified for reranking")
+        # Use self.model if model is None
+        model_to_use = model if model is not None else self.model
+        if model_to_use is None:  # This should never happen due to validator
+            raise ValueError("No model specified for reranking")
 
-            rerank_result = await client.inference.rerank(
-                model=model_to_use,
-                query=query,
-                documents=docs,
-                rank_fields=rank_fields or self.rank_fields or ["text"],
-                top_n=top_n or self.top_n,
-                return_documents=self.return_documents,
-                parameters=self._rerank_params(model=model_to_use, truncate=truncate),
-            )
+        rerank_result = await client.inference.rerank(
+            model=model_to_use,
+            query=query,
+            documents=docs,
+            rank_fields=rank_fields or self.rank_fields or ["text"],
+            top_n=top_n or self.top_n,
+            return_documents=self.return_documents,
+            parameters=self._rerank_params(model=model_to_use, truncate=truncate),
+        )
 
-            result_dicts = []
-            for result_item_data in rerank_result.data:
-                result_dict = {
-                    "id": result_item_data.document.id,
-                    "index": result_item_data.index,
-                    "score": result_item_data.score,
-                }
+        result_dicts = []
+        for result_item_data in rerank_result.data:
+            result_dict = {
+                "id": result_item_data.document.id,
+                "index": result_item_data.index,
+                "score": result_item_data.score,
+            }
 
-                if self.return_documents:
-                    result_dict["document"] = result_item_data.document.to_dict()
+            if self.return_documents:
+                result_dict["document"] = result_item_data.document.to_dict()
 
-                result_dicts.append(result_dict)
+            result_dicts.append(result_dict)
 
-            return result_dicts
-        except Exception as e:
-            logger.error(f"Async rerank error: {e}")
-            return []
+        return result_dicts
 
     def compress_documents(
         self,

--- a/libs/pinecone/tests/unit_tests/test_rerank.py
+++ b/libs/pinecone/tests/unit_tests/test_rerank.py
@@ -240,6 +240,17 @@ class TestPineconeRerank:
         assert results == []
         mock_pinecone_client.inference.rerank.assert_not_called()
 
+    def test_rerank_client_raises_propagates_exception(
+        self, mock_pinecone_client: MagicMock
+    ) -> None:
+        """Test that a client-side exception propagates instead of returning []."""
+        mock_pinecone_client.inference.rerank.side_effect = RuntimeError("API error")
+        reranker = PineconeRerank(
+            client=mock_pinecone_client, model="test-model", pinecone_api_key=API_KEY
+        )
+        with pytest.raises(RuntimeError, match="API error"):
+            reranker.rerank(["some document"], "query")
+
     @pytest.mark.parametrize(
         "model,expected_parameters",
         [
@@ -473,6 +484,22 @@ class TestPineconeRerank:
         results = await reranker.arerank([], "query")
         assert results == []
         mock_pinecone_async_client.inference.rerank.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_arerank_client_raises_propagates_exception(
+        self, mock_pinecone_async_client: MagicMock
+    ) -> None:
+        """Test that a client-side exception propagates instead of returning []."""
+        mock_pinecone_async_client.inference.rerank.side_effect = RuntimeError(
+            "API error"
+        )
+        reranker = PineconeRerank(
+            async_client=mock_pinecone_async_client,
+            model="test-model",
+            pinecone_api_key=API_KEY,
+        )
+        with pytest.raises(RuntimeError, match="API error"):
+            await reranker.arerank(["some document"], "query")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

`rerank` and `arerank` wrapped the Pinecone client call in a broad `except Exception` that logged
the error and silently returned `[]`. This made real API failures (authentication errors, rate
limits, network issues, unsupported model errors) indistinguishable from legitimately empty results,
violating the package's error contract and masking problems from callers.

Identified in internal maintenance review; aligns with the error-handling convention documented in
this codebase: _"An API/network error must propagate, never be converted into an empty result that
callers can't distinguish from 'no data.'"_

## Solution

- Remove the `try/except Exception … return []` wrappers in `rerank` and `arerank` so all
  exceptions propagate unchanged to the caller.
- Preserve the `len(documents) == 0 → []` early-return (genuinely empty input is still a
  legitimate `[]`).
- Remove the now-unused `logging` import and `logger` module-level variable.
- Add two new unit tests (`test_rerank_client_raises_propagates_exception` and
  `test_arerank_client_raises_propagates_exception`) that assert a raising client surfaces the
  exception for both the sync and async paths.

## Behaviour change note

This is an intentional error-contract change. Callers that relied on `[]`-on-error to absorb
failures silently will now observe the underlying exception — which is the correct behaviour: they
can now distinguish "no results" from "the call failed."

## Gate status

Unit tests (`make test`): ✅ pass (122 collected, 121 passed, 1 skipped)
Lint + mypy (`make lint`): ✅ pass
Integration tests (`make integration_test`): ⚠️ skipped — `PINECONE_API_KEY` / `OPENAI_API_KEY`
not available in the build environment (`GATE_SKIP_INTEGRATION=1` override used and logged).