### PR TITLE
fix(embeddings): use query_params in aembed_query

### DIFF
--- a/libs/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/pinecone/langchain_pinecone/embeddings.py
@@ -241,7 +241,7 @@ class PineconeEmbeddings(BaseModel, Embeddings):
         """Asynchronously embed query text."""
         embeddings = await self._aembed_texts(
             model=self.model,
-            parameters=self.document_params,
+            parameters=self.query_params,
             texts=[text],
         )
         return embeddings[0]["values"]

--- a/libs/pinecone/tests/unit_tests/test_embeddings.py
+++ b/libs/pinecone/tests/unit_tests/test_embeddings.py
@@ -325,3 +325,40 @@ class TestPineconeSparseEmbeddingsResponseParsing:
         assert isinstance(result, SparseValues)
         assert result.indices == [1, 5]
         assert result.values == [0.1, 0.2]
+
+
+class TestQueryParamsParity:
+    """Regression tests: query ops must use query_params, not document_params."""
+
+    def test_embed_query_uses_query_params(self, mocker: Any) -> None:
+        embeddings = PineconeEmbeddings(model=MODEL_NAME, pinecone_api_key=API_KEY)
+        mock_embed = mocker.Mock(return_value=[{"values": [0.1, 0.2, 0.3]}])
+        mocker.patch.object(embeddings, "_embed_texts", mock_embed)
+
+        embeddings.embed_query("test query")
+
+        assert mock_embed.call_args.kwargs["parameters"] == embeddings.query_params
+
+    async def test_aembed_query_uses_query_params(self, mocker: Any) -> None:
+        embeddings = PineconeEmbeddings(model=MODEL_NAME, pinecone_api_key=API_KEY)
+        mock_aembed = mocker.AsyncMock(return_value=[{"values": [0.1, 0.2, 0.3]}])
+        mocker.patch.object(embeddings, "_aembed_texts", mock_aembed)
+
+        await embeddings.aembed_query("test query")
+
+        assert mock_aembed.call_args.kwargs["parameters"] == embeddings.query_params
+
+    async def test_sparse_aembed_query_uses_query_params(self, mocker: Any) -> None:
+        sparse_embeddings = PineconeSparseEmbeddings(
+            model=SPARSE_MODEL_NAME, pinecone_api_key=API_KEY
+        )
+        mock_aembed = mocker.AsyncMock(
+            return_value=[{"sparse_indices": [0, 1], "sparse_values": [0.5, 0.5]}]
+        )
+        mocker.patch.object(sparse_embeddings, "_aembed_texts", mock_aembed)
+
+        await sparse_embeddings.aembed_query("test query")
+
+        assert (
+            mock_aembed.call_args.kwargs["parameters"] == sparse_embeddings.query_params
+        )


### PR DESCRIPTION
## Purpose

`PineconeEmbeddings.aembed_query` was passing `self.document_params`
(`input_type: "passage"`) to `_aembed_texts` while the synchronous
`embed_query` correctly passes `self.query_params` (`input_type: "query"`).
This means async callers embedding a query string were inadvertently using
passage-style embeddings, which degrades retrieval quality.

## Solution

One-line fix: change `parameters=self.document_params` →
`parameters=self.query_params` in `PineconeEmbeddings.aembed_query`.

The sparse twin (`PineconeSparseEmbeddings.aembed_query`) already used
`query_params` correctly; this PR pins that contract with a test.

Three regression tests added to `TestQueryParamsParity`:
- `test_embed_query_uses_query_params` — pins the sync contract
- `test_aembed_query_uses_query_params` — **fails before this fix, passes after**
- `test_sparse_aembed_query_uses_query_params` — pins the sparse async contract

## Notes

Integration gate was skipped locally (credentials unavailable); unit tests,
lint, and mypy all pass (`make test && make lint`).