### PR TITLE
chore(deps): make simsimd an optional extra instead of a required runtime dep

### DIFF
--- a/libs/pinecone/pyproject.toml
+++ b/libs/pinecone/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "pinecone[asyncio]>=6.0.0,<8.0.0",
     "numpy>=1.26.4,!=2.0.2",
     "httpx>=0.28.0",
-    "simsimd>=5.9.11",
     "pydantic>=2.11.1",
 ]
 name = "langchain-pinecone"
@@ -24,6 +23,9 @@ readme = "README.md"
 "Release Notes" = "https://github.com/langchain-ai/langchain/releases?q=tag%3A%22langchain-pinecone%3D%3D0%22&expanded=true"
 repository = "https://github.com/langchain-ai/langchain-pinecone"
 
+[project.optional-dependencies]
+speedups = ["simsimd>=5.9.11"]
+
 [dependency-groups]
 test = [
     "pytest>=9.0.3,<10",
@@ -35,6 +37,7 @@ test = [
     "pytest-asyncio>=1.0.0,<2",
     "pytest-socket<1.0.0,>=0.7.0",
     "langchain-tests>=0.3.17",
+    "simsimd>=5.9.11",
 ]
 codespell = ["codespell<3.0.0,>=2.2.0"]
 test_integration = []

--- a/libs/pinecone/uv.lock
+++ b/libs/pinecone/uv.lock
@@ -811,6 +811,10 @@ dependencies = [
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pinecone", extra = ["asyncio"] },
     { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+speedups = [
     { name = "simsimd" },
 ]
 
@@ -835,6 +839,7 @@ test = [
     { name = "pytest-mock" },
     { name = "pytest-socket" },
     { name = "pytest-watcher" },
+    { name = "simsimd" },
     { name = "syrupy" },
 ]
 typing = [
@@ -849,8 +854,9 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.4,!=2.0.2" },
     { name = "pinecone", extras = ["asyncio"], specifier = ">=6.0.0,<8.0.0" },
     { name = "pydantic", specifier = ">=2.11.1" },
-    { name = "simsimd", specifier = ">=5.9.11" },
+    { name = "simsimd", marker = "extra == 'speedups'", specifier = ">=5.9.11" },
 ]
+provides-extras = ["speedups"]
 
 [package.metadata.requires-dev]
 codespell = [{ name = "codespell", specifier = ">=2.2.0,<3.0.0" }]
@@ -869,6 +875,7 @@ test = [
     { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
     { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
+    { name = "simsimd", specifier = ">=5.9.11" },
     { name = "syrupy", specifier = ">=5.0.0,<6" },
 ]
 test-integration = []


### PR DESCRIPTION
## Purpose

`simsimd` is declared a hard runtime dependency but `cosine_similarity()` in
`_utilities.py` already treats it as optional — it wraps the import in a
`try/except ImportError` and falls back to a NumPy implementation.
Keeping it as a required runtime dep is misleading and forces every consumer to
install a compiled binary wheel they may not need.

This resolves the dependency-surface hygiene finding from the harness audit
(2026-06-11).

## Solution

- Remove `simsimd` from `[project].dependencies`.
- Add `[project.optional-dependencies]` with `speedups = ["simsimd>=5.9.11"]`
  so users who want the accelerated cosine path can opt in with
  `pip install langchain-pinecone[speedups]`.
- Keep the `typing` dependency-group entry (`simsimd<6.0.0,>=5.0.0`) so strict
  mypy can still resolve and type-check the import.
- Add `simsimd>=5.9.11` to the `test` dependency group so CI continues to
  install it and `test_cosine_similarity_simsimd_path` exercises the
  accelerated path.
- Regenerate `uv.lock`.

The NumPy fallback path and the simsimd-accelerated path are both covered by
unit tests (added in a prior PR): `test_cosine_similarity_numpy_fallback` forces
an `ImportError` to exercise the fallback; `test_cosine_similarity_simsimd_path`
asserts numeric parity between both paths within `1e-5` tolerance.

## Checklist

- [x] `simsimd` absent from `[project].dependencies`
- [x] `simsimd` available via `langchain-pinecone[speedups]`
- [x] `typing` group entry unchanged (mypy still resolves the import)
- [x] `simsimd` in `test` group (CI still exercises accelerated path)
- [x] `uv.lock` regenerated and consistent
- [x] `make test` — 167 passed, 1 skipped (unrelated)
- [x] `make lint` — ruff + mypy clean
- [x] Public API unchanged