### PR TITLE
fix(vectorstores): forward pinecone_api_key kwarg in from_texts

### DIFF
--- a/libs/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/pinecone/langchain_pinecone/vectorstores.py
@@ -973,7 +973,9 @@ class PineconeVectorStore(VectorStore):
             )
             ```
         """
-        pinecone_index = cls.get_pinecone_index(index_name, pool_threads)
+        pinecone_index = cls.get_pinecone_index(
+            index_name, pool_threads, pinecone_api_key=kwargs.get("pinecone_api_key")
+        )
         pinecone = cls(pinecone_index, embedding, text_key, namespace, **kwargs)
 
         pinecone.add_texts(

--- a/libs/pinecone/tests/unit_tests/test_vectorstores.py
+++ b/libs/pinecone/tests/unit_tests/test_vectorstores.py
@@ -1225,6 +1225,45 @@ async def test_asimilarity_search__honors_constructor_namespace(
     assert mock_async_index.query.call_args.kwargs["namespace"] == "constructor-ns"
 
 
+# --- FIX-002: from_texts forwards pinecone_api_key to get_pinecone_index (issue #110) ---
+
+
+def test_from_texts_forwards_pinecone_api_key(
+    mocker: MockerFixture, mock_index: MockType, mock_embedding: AsyncMockType
+) -> None:
+    """from_texts passes the pinecone_api_key kwarg through to get_pinecone_index."""
+    mock_get_index = mocker.patch.object(
+        PineconeVectorStore, "get_pinecone_index", return_value=mock_index
+    )
+    mock_embedding.embed_documents = mocker.Mock(return_value=[[0.1, 0.2, 0.3]])
+
+    PineconeVectorStore.from_texts(
+        ["text"],
+        mock_embedding,
+        index_name="my-index",
+        pinecone_api_key="caller-supplied-key",
+        async_req=False,
+    )
+
+    mock_get_index.assert_called_once_with(
+        "my-index", 4, pinecone_api_key="caller-supplied-key"
+    )
+
+
+def test_from_texts_raises_when_no_api_key(
+    mocker: MockerFixture, mock_embedding: AsyncMockType
+) -> None:
+    """from_texts raises ValueError when neither pinecone_api_key kwarg nor env var is set."""
+    mocker.patch.dict("os.environ", {"PINECONE_API_KEY": ""})
+
+    with pytest.raises(ValueError, match="Pinecone API key"):
+        PineconeVectorStore.from_texts(
+            ["text"],
+            mock_embedding,
+            index_name="my-index",
+        )
+
+
 def test_similarity_score_threshold_retriever__honors_constructor_namespace(
     mocker: MockerFixture,
     mock_embedding: AsyncMockType,


### PR DESCRIPTION
## Purpose

`PineconeVectorStore.from_texts(..., pinecone_api_key=<key>)` raised `ValueError: Pinecone API key must be provided` even when the caller supplied the key, because the key was never forwarded to the internal `get_pinecone_index` call. `from_documents` delegates to `from_texts` and exhibited the same failure (the traceback from issue #110).

## Solution

In `from_texts`, read `pinecone_api_key` from `kwargs` and pass it to `get_pinecone_index`. The key remains in `kwargs` so the subsequent `cls(pinecone_index, embedding, ...)` constructor call is unaffected — the constructor's `if index:` branch takes the key from `index.config.api_key` and ignores the kwarg. No public signature changes.

Added two unit tests:
- `test_from_texts_forwards_pinecone_api_key`: asserts `get_pinecone_index` is called with the caller-supplied key.
- `test_from_texts_raises_when_no_api_key`: asserts `ValueError` is raised when neither kwarg nor `PINECONE_API_KEY` env var is set.

Closes #110