### PR TITLE
test(integration): add MMR integration tests for dense and sparse vector stores

### DIFF
--- a/libs/pinecone/tests/integration_tests/test_vectorstores.py
+++ b/libs/pinecone/tests/integration_tests/test_vectorstores.py
@@ -769,3 +769,91 @@ class TestPinecone:
         stats = _poll_for_vector_count_at_most(self.index, ns, 0)
         remaining = stats.get("namespaces", {}).get(ns, {}).get("vector_count", 0)
         assert remaining == 0
+
+    def test_max_marginal_relevance_search(
+        self, embeddings: PineconeEmbeddings
+    ) -> None:
+        """Dense MMR returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"mmr-dense-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        docsearch = PineconeVectorStore.from_texts(
+            corpus, embeddings, index_name=INDEX_NAME, namespace=ns
+        )
+        results = _poll_for_results(
+            lambda: docsearch.max_marginal_relevance_search(
+                "alpha", k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2
+
+    def test_max_marginal_relevance_search_by_vector(
+        self, embeddings: PineconeEmbeddings
+    ) -> None:
+        """Dense MMR by vector returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"mmr-dense-bv-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        docsearch = PineconeVectorStore.from_texts(
+            corpus, embeddings, index_name=INDEX_NAME, namespace=ns
+        )
+        query_embedding = embeddings.embed_query("alpha")
+        results = _poll_for_results(
+            lambda: docsearch.max_marginal_relevance_search_by_vector(
+                query_embedding, k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2
+
+    @pytest.mark.asyncio
+    async def test_amax_marginal_relevance_search(
+        self, embeddings: PineconeEmbeddings
+    ) -> None:
+        """Async dense MMR returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"mmr-dense-async-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        docsearch = await PineconeVectorStore.afrom_texts(
+            corpus, embeddings, index_name=INDEX_NAME, namespace=ns
+        )
+        results = await _apoll_for_results(
+            lambda: docsearch.amax_marginal_relevance_search(
+                "alpha", k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2
+
+    @pytest.mark.asyncio
+    async def test_amax_marginal_relevance_search_by_vector(
+        self, embeddings: PineconeEmbeddings
+    ) -> None:
+        """Async dense MMR by vector returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"mmr-dense-bv-async-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        docsearch = await PineconeVectorStore.afrom_texts(
+            corpus, embeddings, index_name=INDEX_NAME, namespace=ns
+        )
+        query_embedding = await embeddings.aembed_query("alpha")
+        results = await _apoll_for_results(
+            lambda: docsearch.amax_marginal_relevance_search_by_vector(
+                query_embedding, k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2

--- a/libs/pinecone/tests/integration_tests/test_vectorstores_sparse.py
+++ b/libs/pinecone/tests/integration_tests/test_vectorstores_sparse.py
@@ -1,0 +1,262 @@
+import os
+import time
+import uuid
+from datetime import datetime
+from typing import Any, List
+
+import pytest
+from langchain_core.utils import convert_to_secret_str
+from pinecone import AwsRegion, CloudProvider, Metric, ServerlessSpec, VectorType
+from pytest_mock import MockerFixture  # type: ignore[import-not-found]
+
+from langchain_pinecone.embeddings import PineconeSparseEmbeddings
+from langchain_pinecone.vectorstores_sparse import PineconeSparseVectorStore
+from tests.integration_tests.test_vectorstores import (
+    DEFAULT_SLEEP,
+    _apoll_for_results,
+    _poll_for_results,
+    _sweep_stale_langchain_test_indexes,
+)
+
+SPARSE_MODEL_NAME = "pinecone-sparse-english-v0"
+_SPARSE_PREFIX = "langchain-test-sparse-"
+INDEX_NAME = f"{_SPARSE_PREFIX}{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+requires_api_key = pytest.mark.skipif(
+    not os.environ.get("PINECONE_API_KEY"),
+    reason="Pinecone API key not set",
+)
+
+
+class TestPineconeSparseVectorStore:
+    index: Any
+    pc: Any
+
+    @classmethod
+    def setup_class(cls) -> None:
+        if not os.environ.get("PINECONE_API_KEY"):
+            pytest.skip("PINECONE_API_KEY not set")
+
+        import pinecone
+
+        client = pinecone.Pinecone()
+        _sweep_stale_langchain_test_indexes(client, _SPARSE_PREFIX)
+        if client.has_index(name=INDEX_NAME):
+            client.delete_index(INDEX_NAME)
+            time.sleep(DEFAULT_SLEEP)
+        client.create_index(
+            name=INDEX_NAME,
+            metric=Metric.DOTPRODUCT,
+            spec=ServerlessSpec(cloud=CloudProvider.AWS, region=AwsRegion.US_WEST_2),
+            vector_type=VectorType.SPARSE,
+        )
+        ready_deadline = time.monotonic() + 300
+        while not client.describe_index(INDEX_NAME).status["ready"]:
+            if time.monotonic() > ready_deadline:
+                raise TimeoutError(f"Index {INDEX_NAME} not ready after 300 s")
+            time.sleep(1)
+        cls.index = client.Index(INDEX_NAME)
+        cls.pc = client
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        cls.pc.delete_index(INDEX_NAME)
+
+    @pytest.fixture(autouse=True)
+    def patch_sparse_model_listing(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "langchain_pinecone.embeddings.PineconeEmbeddings.list_supported_models",
+            return_value=[{"model": SPARSE_MODEL_NAME}],
+        )
+
+    @pytest.fixture
+    def embeddings(self) -> PineconeSparseEmbeddings:
+        return PineconeSparseEmbeddings(
+            model=SPARSE_MODEL_NAME,
+            pinecone_api_key=convert_to_secret_str(
+                os.environ.get("PINECONE_API_KEY", "")
+            ),
+        )
+
+    @pytest.fixture
+    def store(self, embeddings: PineconeSparseEmbeddings) -> PineconeSparseVectorStore:
+        return PineconeSparseVectorStore(
+            index=self.index,
+            embedding=embeddings,
+        )
+
+    @requires_api_key
+    def test_add_texts_and_similarity_search(
+        self,
+        store: PineconeSparseVectorStore,
+    ) -> None:
+        unique_id = uuid.uuid4().hex
+        sentinel = f"langchain sparse test {unique_id}"
+        texts: List[str] = ["foo", "bar", "baz", sentinel]
+        namespace = f"sync-search-{unique_id}"
+
+        store.add_texts(texts, namespace=namespace)
+        results = _poll_for_results(
+            lambda: store.similarity_search(sentinel, k=1, namespace=namespace),
+        )
+        assert len(results) >= 1
+        assert results[0].page_content == sentinel
+
+    @requires_api_key
+    def test_similarity_search_with_score(
+        self,
+        store: PineconeSparseVectorStore,
+    ) -> None:
+        unique_id = uuid.uuid4().hex
+        sentinel = f"langchain sparse score test {unique_id}"
+        texts: List[str] = ["foo", "bar", sentinel]
+        namespace = f"sync-score-{unique_id}"
+
+        store.add_texts(texts, namespace=namespace)
+        results = _poll_for_results(
+            lambda: store.similarity_search_with_score(
+                sentinel, k=3, namespace=namespace
+            ),
+            min_count=3,
+        )
+        assert len(results) >= 1
+        docs_and_scores = results
+        best_doc, best_score = max(docs_and_scores, key=lambda x: x[1])
+        assert best_doc.page_content == sentinel
+        for doc, score in docs_and_scores:
+            if doc.page_content != sentinel:
+                assert best_score >= score
+
+    @requires_api_key
+    @pytest.mark.asyncio
+    async def test_aadd_texts_and_asimilarity_search(
+        self,
+        store: PineconeSparseVectorStore,
+    ) -> None:
+        unique_id = uuid.uuid4().hex
+        sentinel = f"langchain sparse async test {unique_id}"
+        texts: List[str] = ["foo", "bar", "baz", sentinel]
+        namespace = f"async-search-{unique_id}"
+
+        await store.aadd_texts(texts, namespace=namespace)
+        results = await _apoll_for_results(
+            lambda: store.asimilarity_search(sentinel, k=1, namespace=namespace),
+        )
+        assert len(results) >= 1
+        assert results[0].page_content == sentinel
+
+    @requires_api_key
+    @pytest.mark.asyncio
+    async def test_asimilarity_search_with_score(
+        self,
+        store: PineconeSparseVectorStore,
+    ) -> None:
+        unique_id = uuid.uuid4().hex
+        sentinel = f"langchain sparse async score test {unique_id}"
+        texts: List[str] = ["foo", "bar", sentinel]
+        namespace = f"async-score-{unique_id}"
+
+        await store.aadd_texts(texts, namespace=namespace)
+        results = await _apoll_for_results(
+            lambda: store.asimilarity_search_with_score(
+                sentinel, k=3, namespace=namespace
+            ),
+            min_count=3,
+        )
+        assert len(results) >= 1
+        docs_and_scores = results
+        best_doc, best_score = max(docs_and_scores, key=lambda x: x[1])
+        assert best_doc.page_content == sentinel
+        for doc, score in docs_and_scores:
+            if doc.page_content != sentinel:
+                assert best_score >= score
+
+    @requires_api_key
+    def test_max_marginal_relevance_search(
+        self,
+        store: PineconeSparseVectorStore,
+    ) -> None:
+        """Sparse MMR returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"sparse-mmr-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        store.add_texts(corpus, namespace=ns)
+        results = _poll_for_results(
+            lambda: store.max_marginal_relevance_search(
+                "alpha", k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2
+
+    @requires_api_key
+    def test_max_marginal_relevance_search_by_vector(
+        self,
+        store: PineconeSparseVectorStore,
+        embeddings: PineconeSparseEmbeddings,
+    ) -> None:
+        """Sparse MMR by vector returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"sparse-mmr-bv-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        store.add_texts(corpus, namespace=ns)
+        query_embedding = embeddings.embed_query("alpha")
+        results = _poll_for_results(
+            lambda: store.max_marginal_relevance_search_by_vector(
+                query_embedding, k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2
+
+    @requires_api_key
+    @pytest.mark.asyncio
+    async def test_amax_marginal_relevance_search(
+        self,
+        store: PineconeSparseVectorStore,
+    ) -> None:
+        """Async sparse MMR returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"sparse-mmr-async-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        await store.aadd_texts(corpus, namespace=ns)
+        results = await _apoll_for_results(
+            lambda: store.amax_marginal_relevance_search(
+                "alpha", k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2
+
+    @requires_api_key
+    @pytest.mark.asyncio
+    async def test_amax_marginal_relevance_search_by_vector(
+        self,
+        store: PineconeSparseVectorStore,
+        embeddings: PineconeSparseEmbeddings,
+    ) -> None:
+        """Async sparse MMR by vector returns k distinct documents drawn from the corpus."""
+        unique_id = uuid.uuid4().hex[:8]
+        ns = f"sparse-mmr-bv-async-{unique_id}"
+        corpus = ["alpha one", "beta two", "gamma three", "delta four"]
+        await store.aadd_texts(corpus, namespace=ns)
+        query_embedding = await embeddings.aembed_query("alpha")
+        results = await _apoll_for_results(
+            lambda: store.amax_marginal_relevance_search_by_vector(
+                query_embedding, k=2, fetch_k=4, namespace=ns
+            ),
+            min_count=2,
+        )
+        assert len(results) == 2
+        texts_returned = [doc.page_content for doc in results]
+        assert all(t in corpus for t in texts_returned)
+        assert len(set(texts_returned)) == 2


### PR DESCRIPTION
## Purpose

MMR (`max_marginal_relevance_search`) is the integration path most sensitive to SDK
response-shape changes: it calls `query(include_values=True)` and feeds the raw returned
vectors into the MMR math in `_utilities.py`. Currently there are **no working integration
tests** for the MMR path — only two `@pytest.mark.xfail` relevance-score tests that don't
exercise MMR at all. A Pinecone SDK version change that reorders or renames vector fields
in the query response would break MMR silently.

This PR adds end-to-end integration coverage as a prerequisite for the paused SDK-001
(pinecone 8 upgrade).

## Solution

**`test_vectorstores.py` (dense)** — 4 new methods added to `TestPinecone`:
- `test_max_marginal_relevance_search` — upserts 4 docs, `k=2 fetch_k=4`; asserts 2 distinct docs from corpus
- `test_max_marginal_relevance_search_by_vector` — same via a pre-embedded query vector
- `test_amax_marginal_relevance_search` — async twin of query-based MMR
- `test_amax_marginal_relevance_search_by_vector` — async twin of vector-based MMR

**`test_vectorstores_sparse.py` (sparse)** — new file `TestPineconeSparseVectorStore`:
- Includes the similarity-search coverage from PR #134 (TC-009), making this a superset
- Adds 4 sparse MMR variants (sync + async, query + by-vector) using `PineconeSparseVectorStore`
- Sparse MMR exercises the `SparseValues.from_dict` path on the query response

Each test uses a unique uuid namespace to avoid cross-test contamination.

> **Note:** This PR supersedes #134 for the sparse file. If #134 is merged first, a rebase
> will be needed to resolve the `test_vectorstores_sparse.py` conflict (take this file, which
> is a strict superset).