### PR TITLE
test(vectorstores,embeddings): assert version-shim imports resolve to classes

### DIFF
--- a/libs/pinecone/tests/unit_tests/test_import_shims.py
+++ b/libs/pinecone/tests/unit_tests/test_import_shims.py
@@ -1,0 +1,45 @@
+"""
+Asserts that the conditional import shims in vectorstores.py and embeddings.py
+resolve to real, non-None classes on the installed pinecone version.
+
+Both sources use try/except ImportError to pick the correct module path across
+pinecone major versions. If both branches of a shim fail simultaneously the
+binding goes missing silently; this test file catches that failure mode.
+"""
+
+import inspect
+
+import langchain_pinecone.embeddings as _embeddings_mod
+import langchain_pinecone.vectorstores as _vectorstores_mod
+from langchain_pinecone.vectorstores import ApplyResult, _Index, _IndexAsyncio
+
+
+def test_vectorstores_index_shim_resolves() -> None:
+    assert _Index is not None
+    assert inspect.isclass(_Index)
+
+
+def test_vectorstores_index_asyncio_shim_resolves() -> None:
+    assert _IndexAsyncio is not None
+    assert inspect.isclass(_IndexAsyncio)
+
+
+def test_vectorstores_apply_result_shim_resolves() -> None:
+    assert ApplyResult is not None
+    assert inspect.isclass(ApplyResult)
+
+
+def test_embeddings_embeddings_list_shim_resolves() -> None:
+    EmbeddingsList = _embeddings_mod.EmbeddingsList  # type: ignore[attr-defined]
+    assert EmbeddingsList is not None
+    assert inspect.isclass(EmbeddingsList)
+
+
+def test_vectorstores_shim_names_in_module_namespace() -> None:
+    assert hasattr(_vectorstores_mod, "_Index")
+    assert hasattr(_vectorstores_mod, "_IndexAsyncio")
+    assert hasattr(_vectorstores_mod, "ApplyResult")
+
+
+def test_embeddings_shim_name_in_module_namespace() -> None:
+    assert hasattr(_embeddings_mod, "EmbeddingsList")


### PR DESCRIPTION
## Purpose

Adds `tests/unit_tests/test_import_shims.py` to guard the conditional
(`try/except ImportError`) import shims in `vectorstores.py` and `embeddings.py`
against silent binding failures.

Both modules pick their SDK import path at module load time:

- `vectorstores.py`: resolves `_Index`, `_IndexAsyncio`, `ApplyResult` across
  `pinecone.db_data.index` (v8+) and `pinecone.data` (v7 and below).
- `embeddings.py`: resolves `EmbeddingsList` across
  `pinecone.core.openapi.inference.model.embeddings_list` (v7+) and
  `pinecone.data.features.inference.inference` (older).

If both branches of a shim fail (e.g. after a pinecone package reorganization),
the names bind silently to nothing and the failure surfaces as an `AttributeError`
or confusing empty results far from the true root cause.

## Solution

Six unit tests assert that each shimmed name:
1. Is bound in the module namespace (`hasattr`).
2. Is not `None`.
3. Is a real class (`inspect.isclass`).

Tests run entirely in the unit tier — no credentials needed, socket-disabled — and
are version-agnostic: they pass on the current pinecone `<8` pin and will continue
to pass after the SDK-001 bump, making them a true regression guardrail for that
upgrade.

Closes / addresses: prerequisite guardrail for #93 / #95 (SDK-001 pinecone 8 upgrade).